### PR TITLE
Add onboarding wizard and daily log UI (Step 3)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -121,6 +121,56 @@ C4Component
 
 ---
 
+## Level 3: Component Diagram — Frontend
+
+What components make up the frontend SPA?
+
+```mermaid
+C4Component
+    title Somnus Frontend — Component Diagram
+
+    Container_Boundary(frontend, "Frontend SPA") {
+
+        Component(router, "Router", "react-router-dom v7", "URL-based routing. /onboarding, /log/:date. Layout guard checks onboarding status.")
+
+        Component(layout, "Layout", "React", "Nav header with app title. Onboarding gate — redirects based on settings.onboarding_completed.")
+
+        Component_Boundary(onboarding, "Onboarding Wizard") {
+            Component(wizard, "OnboardingWizard", "React", "6-step wizard: Welcome, Oura, SleepProfile, TrackingSetup, DataStorage, Done. Per-step PATCH to settings.")
+        }
+
+        Component_Boundary(daily_log, "Daily Log") {
+            Component(daily_log_page, "DailyLogPage", "React", "Assembles date nav, sections, caffeine chart, notes, save button. Whole-log PUT on save.")
+            Component(date_nav, "DateNavigator", "React", "Date display with prev/next/today. Date in URL param.")
+            Component(copy_day, "CopyDayButton", "React", "Date picker modal to copy entries from another day.")
+            Component(warning_banner, "WarningBanner", "React", "Dismissible validation warnings from backend.")
+            Component(sections, "Entry Sections", "React", "11 collapsible sections: Caffeine, Meals, Supplements, Habits, Stimulating, Sexual Activity, Pre-Bed Rituals, Naps, Sunlight, Red Light, NSDR.")
+        }
+
+        Component(caffeine_chart, "CaffeineChart", "SVG", "Inline SVG decay curve. Client-side exponential decay math. Bedtime marker and 100mg threshold.")
+
+        Component_Boundary(api_layer, "API Client") {
+            Component(api_client, "fetchJson/fetchVoid", "TypeScript", "Thin fetch wrapper with JSON parsing and ApiError handling.")
+            Component(api_modules, "Endpoint Modules", "TypeScript", "dailyLog, settings, redLightPanels API functions.")
+        }
+
+        Component(shared, "Shared Components", "React", "TimePicker, NumberInput, SelectInput, SliderInput, Toggle.")
+
+        Component(hooks, "Custom Hooks", "React", "useSettings, useDailyLog, useOnboarding, useDateNavigation, useCaffeineDecay.")
+    }
+
+    Rel(router, layout, "Renders")
+    Rel(layout, wizard, "Onboarding route")
+    Rel(layout, daily_log_page, "Log route")
+    Rel(daily_log_page, sections, "Renders")
+    Rel(daily_log_page, caffeine_chart, "Renders when caffeine entries exist")
+    Rel(daily_log_page, date_nav, "Renders")
+    Rel(hooks, api_modules, "Calls")
+    Rel(api_modules, api_client, "Uses")
+```
+
+---
+
 ## Data Flow
 
 ### Daily Entry Flow

--- a/docs/adr/008-frontend-routing-and-form-pattern.md
+++ b/docs/adr/008-frontend-routing-and-form-pattern.md
@@ -1,0 +1,42 @@
+# ADR 008: Frontend Routing and Form Pattern
+
+## Status
+Accepted
+
+## Context
+Step 3 introduces the first user-facing frontend: an onboarding wizard and daily log form. We need patterns for client-side routing, navigation guards (onboarding gate), form state management, and data submission.
+
+## Decision
+
+### Routing
+- **react-router-dom v7** for client-side routing.
+- Date embedded in URL: `/log/:date` enables browser back/forward and bookmarks.
+- `/onboarding` for the setup wizard.
+- Layout component acts as guard: redirects to `/onboarding` if `onboarding_completed` is false, and away from `/onboarding` if already completed.
+
+### Form Pattern: Whole-Log PUT
+- The daily log form collects all edits in local React state (`useState` with a `DailyLogCreate` object).
+- On save, the entire object is submitted via `PUT /api/daily-log/{date}`.
+- The backend handles the upsert atomically — deleting old entries and creating new ones.
+- This avoids complex per-entry CRUD from the frontend and prevents race conditions.
+
+### Out-to-Create Transform
+- When loading an existing log via GET, the `useDailyLog` hook strips `id` and `date` from each `*Out` entry to produce `*Create` form state.
+- This keeps the form state shape identical whether creating or editing.
+
+### No Form Library
+- Controlled components with `useState`. The form shape mirrors the Pydantic schema exactly.
+- No Formik, react-hook-form, or similar — the overhead is not justified for a single composite form.
+
+### Onboarding Per-Step Save
+- Each onboarding step PATCHes settings immediately on change.
+- Progress survives browser close since settings are persisted server-side.
+
+### Section Collapse Persistence
+- Each collapsible section stores open/closed state in localStorage.
+- Key format: `somnus-section-{storageKey}`.
+
+## Consequences
+- URL-based date navigation is bookmarkable and shareable.
+- Whole-log PUT is simple but means the entire log is replaced on each save — acceptable for a single-user local app.
+- No form library means manual validation, but Pydantic handles server-side validation and returns warnings.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router-dom": "^7.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -2515,6 +2516,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3761,6 +3775,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -3868,6 +3920,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router-dom": "^7.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { fetchJson, fetchVoid } from './client'
+import { ApiError } from '../types/api'
+
+describe('fetchJson', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns parsed JSON on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ id: 1 }), { status: 200 }),
+    )
+    const result = await fetchJson<{ id: number }>('/api/test')
+    expect(result).toEqual({ id: 1 })
+  })
+
+  it('sends Content-Type header', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 }),
+    )
+    await fetchJson('/api/test')
+    expect(spy).toHaveBeenCalledWith('/api/test', expect.objectContaining({
+      headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+    }))
+  })
+
+  it('throws ApiError with detail on error response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 }),
+    )
+    try {
+      await fetchJson('/api/test')
+      expect.fail('should have thrown')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError)
+      expect((e as ApiError).status).toBe(404)
+      expect((e as ApiError).detail).toBe('Not found')
+    }
+  })
+
+  it('uses statusText when body has no detail', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('not json', { status: 500, statusText: 'Internal Server Error' }),
+    )
+    try {
+      await fetchJson('/api/test')
+    } catch (e) {
+      expect((e as ApiError).detail).toBe('Internal Server Error')
+    }
+  })
+})
+
+describe('fetchVoid', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves on success', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+    await expect(fetchVoid('/api/test', { method: 'DELETE' })).resolves.toBeUndefined()
+  })
+
+  it('throws ApiError on error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Gone' }), { status: 410 }),
+    )
+    await expect(fetchVoid('/api/test')).rejects.toThrow(ApiError)
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,44 @@
+/** Thin fetch wrapper with JSON parsing and error handling. */
+
+import { ApiError } from '../types/api'
+
+export async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!res.ok) {
+    let detail = res.statusText
+    try {
+      const body = (await res.json()) as { detail?: string }
+      if (body.detail) detail = body.detail
+    } catch {
+      // use statusText
+    }
+    throw new ApiError(res.status, detail)
+  }
+  return (await res.json()) as T
+}
+
+export async function fetchVoid(url: string, init?: RequestInit): Promise<void> {
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...init?.headers,
+    },
+  })
+  if (!res.ok) {
+    let detail = res.statusText
+    try {
+      const body = (await res.json()) as { detail?: string }
+      if (body.detail) detail = body.detail
+    } catch {
+      // use statusText
+    }
+    throw new ApiError(res.status, detail)
+  }
+}

--- a/frontend/src/api/dailyLog.test.ts
+++ b/frontend/src/api/dailyLog.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { getDailyLog, saveDailyLog, listDailyLogs, copyDay, deleteDailyLog } from './dailyLog'
+
+function mockFetch(body: unknown, status = 200) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), { status }),
+  )
+}
+
+describe('dailyLog API', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('getDailyLog fetches correct URL', async () => {
+    const spy = mockFetch({ date: '2024-01-01', caffeine_entries: [] })
+    await getDailyLog('2024-01-01')
+    expect(spy).toHaveBeenCalledWith('/api/daily-log/2024-01-01', expect.anything())
+  })
+
+  it('saveDailyLog sends PUT with body', async () => {
+    const spy = mockFetch({ data: { date: '2024-01-01' }, warnings: [] })
+    await saveDailyLog('2024-01-01', {
+      is_sick: null, notes: null,
+      caffeine_entries: [], meal_entries: [], supplement_entries: [],
+      habit_entries: [], stimulating_activity_entries: [],
+      sexual_activity_entry: null, pre_bed_ritual_entries: [],
+      nap_entries: [], sunlight_entries: [], red_light_entries: [],
+      nsdr_entries: [],
+    })
+    expect(spy).toHaveBeenCalledWith('/api/daily-log/2024-01-01', expect.objectContaining({
+      method: 'PUT',
+    }))
+  })
+
+  it('listDailyLogs with no params', async () => {
+    const spy = mockFetch([])
+    await listDailyLogs()
+    expect(spy).toHaveBeenCalledWith('/api/daily-log', expect.anything())
+  })
+
+  it('listDailyLogs with date range', async () => {
+    const spy = mockFetch([])
+    await listDailyLogs('2024-01-01', '2024-01-31')
+    expect(spy).toHaveBeenCalledWith(
+      '/api/daily-log?start_date=2024-01-01&end_date=2024-01-31',
+      expect.anything(),
+    )
+  })
+
+  it('copyDay sends POST', async () => {
+    const spy = mockFetch({ date: '2024-01-02' })
+    await copyDay('2024-01-02', '2024-01-01')
+    expect(spy).toHaveBeenCalledWith(
+      '/api/daily-log/2024-01-02/copy-from/2024-01-01',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('deleteDailyLog sends DELETE', async () => {
+    const spy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    )
+    await deleteDailyLog('2024-01-01')
+    expect(spy).toHaveBeenCalledWith(
+      '/api/daily-log/2024-01-01',
+      expect.objectContaining({ method: 'DELETE' }),
+    )
+  })
+})

--- a/frontend/src/api/dailyLog.ts
+++ b/frontend/src/api/dailyLog.ts
@@ -1,0 +1,36 @@
+/** API functions for daily log endpoints. */
+
+import { fetchJson, fetchVoid } from './client'
+import type { DailyLogCreate, DailyLogOut, DailyLogResponse, DailyLogSummary } from '../types'
+
+export function getDailyLog(date: string): Promise<DailyLogOut> {
+  return fetchJson<DailyLogOut>(`/api/daily-log/${date}`)
+}
+
+export function saveDailyLog(date: string, data: DailyLogCreate): Promise<DailyLogResponse> {
+  return fetchJson<DailyLogResponse>(`/api/daily-log/${date}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  })
+}
+
+export function listDailyLogs(
+  startDate?: string,
+  endDate?: string,
+): Promise<DailyLogSummary[]> {
+  const params = new URLSearchParams()
+  if (startDate) params.set('start_date', startDate)
+  if (endDate) params.set('end_date', endDate)
+  const qs = params.toString()
+  return fetchJson<DailyLogSummary[]>(`/api/daily-log${qs ? `?${qs}` : ''}`)
+}
+
+export function copyDay(targetDate: string, sourceDate: string): Promise<DailyLogOut> {
+  return fetchJson<DailyLogOut>(`/api/daily-log/${targetDate}/copy-from/${sourceDate}`, {
+    method: 'POST',
+  })
+}
+
+export function deleteDailyLog(date: string): Promise<void> {
+  return fetchVoid(`/api/daily-log/${date}`, { method: 'DELETE' })
+}

--- a/frontend/src/api/redLightPanels.ts
+++ b/frontend/src/api/redLightPanels.ts
@@ -1,0 +1,31 @@
+/** API functions for red light panel endpoints. */
+
+import { fetchJson } from './client'
+
+export interface RedLightPanelOut {
+  id: number
+  name: string
+  wavelength_nm: number | null
+  irradiance_mw_cm2: number | null
+  default_distance_inches: number | null
+  notes: string | null
+}
+
+export interface RedLightPanelCreate {
+  name: string
+  wavelength_nm?: number | null
+  irradiance_mw_cm2?: number | null
+  default_distance_inches?: number | null
+  notes?: string | null
+}
+
+export function listPanels(): Promise<RedLightPanelOut[]> {
+  return fetchJson<RedLightPanelOut[]>('/api/red-light-panels')
+}
+
+export function createPanel(data: RedLightPanelCreate): Promise<RedLightPanelOut> {
+  return fetchJson<RedLightPanelOut>('/api/red-light-panels', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
+}

--- a/frontend/src/api/settings.ts
+++ b/frontend/src/api/settings.ts
@@ -1,0 +1,15 @@
+/** API functions for user settings endpoints. */
+
+import { fetchJson } from './client'
+import type { UserSettingsOut, UserSettingsUpdate } from '../types'
+
+export function getSettings(): Promise<UserSettingsOut> {
+  return fetchJson<UserSettingsOut>('/api/settings')
+}
+
+export function updateSettings(data: UserSettingsUpdate): Promise<UserSettingsOut> {
+  return fetchJson<UserSettingsOut>('/api/settings', {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  })
+}

--- a/frontend/src/components/CaffeineChart/CaffeineChart.css
+++ b/frontend/src/components/CaffeineChart/CaffeineChart.css
@@ -1,0 +1,15 @@
+.caffeine-chart {
+  margin-top: 0.5rem;
+}
+
+.caffeine-chart-title {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.caffeine-chart-svg {
+  width: 100%;
+  max-width: 600px;
+  height: auto;
+}

--- a/frontend/src/components/CaffeineChart/CaffeineChart.test.tsx
+++ b/frontend/src/components/CaffeineChart/CaffeineChart.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { CaffeineChart } from './CaffeineChart'
+
+describe('CaffeineChart', () => {
+  it('renders nothing with empty points', () => {
+    const { container } = render(<CaffeineChart points={[]} bedtimeHour={null} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders SVG with points', () => {
+    const points = [
+      { hour: 0, mg: 0 },
+      { hour: 8, mg: 100 },
+      { hour: 12, mg: 50 },
+    ]
+    const { container } = render(<CaffeineChart points={points} bedtimeHour={22.5} />)
+    const svg = container.querySelector('svg')
+    expect(svg).toBeInTheDocument()
+  })
+
+  it('renders polyline', () => {
+    const points = [
+      { hour: 0, mg: 0 },
+      { hour: 8, mg: 100 },
+    ]
+    const { container } = render(<CaffeineChart points={points} bedtimeHour={null} />)
+    const polyline = container.querySelector('polyline')
+    expect(polyline).toBeInTheDocument()
+  })
+
+  it('renders threshold line when max >= 100', () => {
+    const points = [{ hour: 8, mg: 200 }]
+    const { container } = render(<CaffeineChart points={points} bedtimeHour={null} />)
+    // Find the 100mg text label
+    const texts = container.querySelectorAll('text')
+    const has100mg = Array.from(texts).some((t) => t.textContent === '100mg')
+    expect(has100mg).toBe(true)
+  })
+
+  it('renders bedtime marker when provided', () => {
+    const points = [{ hour: 8, mg: 100 }]
+    const { container } = render(<CaffeineChart points={points} bedtimeHour={22} />)
+    const lines = container.querySelectorAll('line')
+    // Should have at least 3 lines: axes + threshold + bedtime
+    expect(lines.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/frontend/src/components/CaffeineChart/CaffeineChart.tsx
+++ b/frontend/src/components/CaffeineChart/CaffeineChart.tsx
@@ -1,0 +1,92 @@
+import type { CaffeinePoint } from './caffeineCalc'
+import './CaffeineChart.css'
+
+interface CaffeineChartProps {
+  points: CaffeinePoint[]
+  bedtimeHour: number | null
+}
+
+const WIDTH = 600
+const HEIGHT = 200
+const PADDING = { top: 20, right: 20, bottom: 30, left: 50 }
+const CHART_W = WIDTH - PADDING.left - PADDING.right
+const CHART_H = HEIGHT - PADDING.top - PADDING.bottom
+
+export function CaffeineChart({ points, bedtimeHour }: CaffeineChartProps) {
+  if (points.length === 0) return null
+
+  const maxMg = Math.max(100, ...points.map((p) => p.mg))
+
+  const x = (hour: number) => PADDING.left + (hour / 24) * CHART_W
+  const y = (mg: number) => PADDING.top + CHART_H - (mg / maxMg) * CHART_H
+
+  const polyline = points.map((p) => `${x(p.hour)},${y(p.mg)}`).join(' ')
+
+  // Threshold line at 100mg
+  const thresholdY = y(100)
+
+  // X-axis labels
+  const xLabels = [0, 6, 12, 18, 24]
+
+  return (
+    <div className="caffeine-chart">
+      <h4 className="caffeine-chart-title">Caffeine Decay</h4>
+      <svg viewBox={`0 0 ${WIDTH} ${HEIGHT}`} className="caffeine-chart-svg">
+        {/* Grid */}
+        <line
+          x1={PADDING.left} y1={PADDING.top}
+          x2={PADDING.left} y2={PADDING.top + CHART_H}
+          stroke="var(--color-border)" strokeWidth="1"
+        />
+        <line
+          x1={PADDING.left} y1={PADDING.top + CHART_H}
+          x2={PADDING.left + CHART_W} y2={PADDING.top + CHART_H}
+          stroke="var(--color-border)" strokeWidth="1"
+        />
+
+        {/* 100mg threshold */}
+        {maxMg >= 100 && (
+          <>
+            <line
+              x1={PADDING.left} y1={thresholdY}
+              x2={PADDING.left + CHART_W} y2={thresholdY}
+              stroke="var(--color-warning)" strokeWidth="1" strokeDasharray="4 4"
+            />
+            <text x={PADDING.left - 4} y={thresholdY + 4} textAnchor="end" fill="var(--color-warning)" fontSize="10">
+              100mg
+            </text>
+          </>
+        )}
+
+        {/* Bedtime marker */}
+        {bedtimeHour != null && (
+          <line
+            x1={x(bedtimeHour)} y1={PADDING.top}
+            x2={x(bedtimeHour)} y2={PADDING.top + CHART_H}
+            stroke="var(--color-error)" strokeWidth="1.5" strokeDasharray="6 3"
+          />
+        )}
+
+        {/* Decay curve */}
+        <polyline
+          points={polyline}
+          fill="none"
+          stroke="var(--color-chart-1)"
+          strokeWidth="2"
+        />
+
+        {/* X-axis labels */}
+        {xLabels.map((h) => (
+          <text key={h} x={x(h)} y={HEIGHT - 5} textAnchor="middle" fill="var(--color-text-muted)" fontSize="10">
+            {h === 0 || h === 24 ? '12a' : h === 12 ? '12p' : h < 12 ? `${h}a` : `${h - 12}p`}
+          </text>
+        ))}
+
+        {/* Y-axis label */}
+        <text x={PADDING.left - 4} y={PADDING.top + 4} textAnchor="end" fill="var(--color-text-muted)" fontSize="10">
+          {Math.round(maxMg)}mg
+        </text>
+      </svg>
+    </div>
+  )
+}

--- a/frontend/src/components/CaffeineChart/caffeineCalc.test.ts
+++ b/frontend/src/components/CaffeineChart/caffeineCalc.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { computeDecayCurve } from './caffeineCalc'
+
+describe('computeDecayCurve', () => {
+  it('returns 96 points (24h * 4 per hour)', () => {
+    const points = computeDecayCurve([], 'normal')
+    expect(points).toHaveLength(96)
+  })
+
+  it('returns all zeros with no entries', () => {
+    const points = computeDecayCurve([], 'normal')
+    expect(points.every((p) => p.mg === 0)).toBe(true)
+  })
+
+  it('starts at dose_mg at entry time', () => {
+    const points = computeDecayCurve(
+      [{ time: '08:00:00', amount_mg: 100 }],
+      'normal',
+    )
+    const at8 = points.find((p) => p.hour === 8)
+    expect(at8?.mg).toBe(100)
+  })
+
+  it('halves at half-life (normal = 4h)', () => {
+    const points = computeDecayCurve(
+      [{ time: '08:00:00', amount_mg: 100 }],
+      'normal',
+    )
+    const at12 = points.find((p) => p.hour === 12)
+    expect(at12?.mg).toBe(50)
+  })
+
+  it('fast metabolizer decays faster', () => {
+    const fast = computeDecayCurve(
+      [{ time: '08:00:00', amount_mg: 100 }],
+      'fast',
+    )
+    const normal = computeDecayCurve(
+      [{ time: '08:00:00', amount_mg: 100 }],
+      'normal',
+    )
+    const fastAt12 = fast.find((p) => p.hour === 12)!.mg
+    const normalAt12 = normal.find((p) => p.hour === 12)!.mg
+    expect(fastAt12).toBeLessThan(normalAt12)
+  })
+
+  it('sums multiple entries', () => {
+    const points = computeDecayCurve(
+      [
+        { time: '08:00:00', amount_mg: 100 },
+        { time: '08:00:00', amount_mg: 50 },
+      ],
+      'normal',
+    )
+    const at8 = points.find((p) => p.hour === 8)
+    expect(at8?.mg).toBe(150)
+  })
+
+  it('ignores entries without time', () => {
+    const points = computeDecayCurve(
+      [{ time: null, amount_mg: 100 }],
+      'normal',
+    )
+    expect(points.every((p) => p.mg === 0)).toBe(true)
+  })
+
+  it('does not count caffeine before entry time', () => {
+    const points = computeDecayCurve(
+      [{ time: '12:00:00', amount_mg: 100 }],
+      'normal',
+    )
+    const at8 = points.find((p) => p.hour === 8)
+    expect(at8?.mg).toBe(0)
+  })
+})

--- a/frontend/src/components/CaffeineChart/caffeineCalc.ts
+++ b/frontend/src/components/CaffeineChart/caffeineCalc.ts
@@ -1,0 +1,49 @@
+/** Pure caffeine decay math. No React dependencies. */
+
+import type { CaffeineSensitivity } from '../../types/enums'
+
+const HALF_LIFE: Record<CaffeineSensitivity, number> = {
+  fast: 2.5,
+  normal: 4.0,
+  slow: 6.0,
+}
+
+export interface CaffeinePoint {
+  hour: number
+  mg: number
+}
+
+export interface CaffeineEntry {
+  time: string | null
+  amount_mg: number
+}
+
+/**
+ * Compute caffeine remaining at each 15-minute interval from 00:00 to 23:45.
+ * remaining_mg = dose_mg * 0.5^(elapsed_hours / half_life)
+ */
+export function computeDecayCurve(
+  entries: CaffeineEntry[],
+  sensitivity: CaffeineSensitivity,
+): CaffeinePoint[] {
+  const halfLife = HALF_LIFE[sensitivity]
+  const points: CaffeinePoint[] = []
+
+  for (let minutes = 0; minutes < 24 * 60; minutes += 15) {
+    const hour = minutes / 60
+    let totalMg = 0
+
+    for (const entry of entries) {
+      if (!entry.time) continue
+      const [h, m] = entry.time.split(':').map(Number)
+      const entryHour = h + m / 60
+      const elapsed = hour - entryHour
+      if (elapsed < 0) continue
+      totalMg += entry.amount_mg * Math.pow(0.5, elapsed / halfLife)
+    }
+
+    points.push({ hour, mg: Math.round(totalMg * 10) / 10 })
+  }
+
+  return points
+}

--- a/frontend/src/components/DailyLog/CopyDayButton.css
+++ b/frontend/src/components/DailyLog/CopyDayButton.css
@@ -1,0 +1,38 @@
+.copy-day-trigger {
+  background: transparent;
+  color: var(--color-text-accent);
+  border: 1px dashed var(--color-border-light);
+  font-size: 0.85rem;
+  padding: 6px 12px;
+}
+
+.copy-day-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg-secondary);
+}
+
+.copy-day-label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.copy-day-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.copy-day-cancel {
+  background: transparent;
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border-light);
+}
+
+.copy-day-error {
+  color: var(--color-error);
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/DailyLog/CopyDayButton.test.tsx
+++ b/frontend/src/components/DailyLog/CopyDayButton.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { CopyDayButton } from './CopyDayButton'
+
+describe('CopyDayButton', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows trigger button initially', () => {
+    render(<CopyDayButton targetDate="2024-06-15" onCopied={vi.fn()} />)
+    expect(screen.getByText('Copy from another day')).toBeInTheDocument()
+  })
+
+  it('shows date picker on click', async () => {
+    const user = userEvent.setup()
+    render(<CopyDayButton targetDate="2024-06-15" onCopied={vi.fn()} />)
+    await user.click(screen.getByText('Copy from another day'))
+    expect(screen.getByText('Copy entries from:')).toBeInTheDocument()
+    expect(screen.getByText('Copy')).toBeInTheDocument()
+    expect(screen.getByText('Cancel')).toBeInTheDocument()
+  })
+
+  it('hides picker on cancel', async () => {
+    const user = userEvent.setup()
+    render(<CopyDayButton targetDate="2024-06-15" onCopied={vi.fn()} />)
+    await user.click(screen.getByText('Copy from another day'))
+    await user.click(screen.getByText('Cancel'))
+    expect(screen.getByText('Copy from another day')).toBeInTheDocument()
+  })
+
+  it('calls API on copy and invokes callback', async () => {
+    const mockLog = { date: '2024-06-15', caffeine_entries: [] }
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockLog)),
+    )
+    const onCopied = vi.fn()
+    const user = userEvent.setup()
+    render(<CopyDayButton targetDate="2024-06-15" onCopied={onCopied} />)
+    await user.click(screen.getByText('Copy from another day'))
+    await user.click(screen.getByText('Copy'))
+    await waitFor(() => {
+      expect(onCopied).toHaveBeenCalledWith(mockLog)
+    })
+  })
+
+  it('shows error on copy failure', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'Source daily log not found' }), { status: 404 }),
+    )
+    const user = userEvent.setup()
+    render(<CopyDayButton targetDate="2024-06-15" onCopied={vi.fn()} />)
+    await user.click(screen.getByText('Copy from another day'))
+    await user.click(screen.getByText('Copy'))
+    await waitFor(() => {
+      expect(screen.getByText('Source daily log not found')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/DailyLog/CopyDayButton.tsx
+++ b/frontend/src/components/DailyLog/CopyDayButton.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react'
+import { copyDay } from '../../api/dailyLog'
+import type { DailyLogOut } from '../../types'
+import './CopyDayButton.css'
+
+interface CopyDayButtonProps {
+  targetDate: string
+  onCopied: (log: DailyLogOut) => void
+}
+
+function yesterdayStr(dateStr: string): string {
+  const d = new Date(dateStr + 'T12:00:00')
+  d.setDate(d.getDate() - 1)
+  return d.toISOString().slice(0, 10)
+}
+
+export function CopyDayButton({ targetDate, onCopied }: CopyDayButtonProps) {
+  const [showPicker, setShowPicker] = useState(false)
+  const [sourceDate, setSourceDate] = useState(yesterdayStr(targetDate))
+  const [copying, setCopying] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCopy = async () => {
+    setCopying(true)
+    setError(null)
+    try {
+      const log = await copyDay(targetDate, sourceDate)
+      onCopied(log)
+      setShowPicker(false)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Copy failed')
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  if (!showPicker) {
+    return (
+      <button type="button" className="copy-day-trigger" onClick={() => setShowPicker(true)}>
+        Copy from another day
+      </button>
+    )
+  }
+
+  return (
+    <div className="copy-day-picker">
+      <label className="copy-day-label">Copy entries from:</label>
+      <input
+        type="date"
+        value={sourceDate}
+        onChange={(e) => setSourceDate(e.target.value)}
+        max={targetDate}
+      />
+      <div className="copy-day-actions">
+        <button type="button" onClick={handleCopy} disabled={copying}>
+          {copying ? 'Copying...' : 'Copy'}
+        </button>
+        <button
+          type="button"
+          className="copy-day-cancel"
+          onClick={() => setShowPicker(false)}
+        >
+          Cancel
+        </button>
+      </div>
+      {error && <p className="copy-day-error">{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/DailyLog/DailyLogPage.css
+++ b/frontend/src/components/DailyLog/DailyLogPage.css
@@ -1,0 +1,45 @@
+.daily-log-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.daily-log-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.daily-log-sections {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.daily-log-notes {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.daily-log-save {
+  position: sticky;
+  bottom: 0;
+  padding: 1rem 0;
+  background: var(--color-bg-primary);
+  border-top: 1px solid var(--color-border);
+}
+
+.daily-log-save-btn {
+  width: 100%;
+  padding: 12px;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.daily-log-save-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/src/components/DailyLog/DailyLogPage.test.tsx
+++ b/frontend/src/components/DailyLog/DailyLogPage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { DailyLogPage } from './DailyLogPage'
+
+const mockLogOut = {
+  date: '2024-06-15',
+  copied_from_date: null,
+  is_sick: null,
+  notes: null,
+  caffeine_entries: [],
+  meal_entries: [],
+  supplement_entries: [],
+  habit_entries: [],
+  stimulating_activity_entries: [],
+  sexual_activity_entry: null,
+  pre_bed_ritual_entries: [],
+  nap_entries: [],
+  sunlight_entries: [],
+  red_light_entries: [],
+  nsdr_entries: [],
+}
+
+const mockSettings = {
+  oura_token_set: false,
+  typical_bedtime: '22:30:00',
+  target_wake_time: '06:30:00',
+  caffeine_sensitivity: 'normal',
+  timezone: 'America/New_York',
+  chronotype: 'intermediate',
+  zip_code: null,
+  age: 30,
+  display_mode: 'circadian',
+  circadian_mode_start: '20:00:00',
+  onboarding_completed: true,
+}
+
+function mockFetch() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    const urlStr = typeof url === 'string' ? url : url.toString()
+    if (urlStr.includes('/api/settings')) {
+      return new Response(JSON.stringify(mockSettings))
+    }
+    if (urlStr.includes('/api/daily-log/') && (!init || !init.method || init.method === 'GET')) {
+      return new Response(JSON.stringify(mockLogOut))
+    }
+    if (urlStr.includes('/api/daily-log/') && init?.method === 'PUT') {
+      return new Response(JSON.stringify({ data: mockLogOut, warnings: [] }))
+    }
+    if (urlStr.includes('/api/red-light-panels')) {
+      return new Response(JSON.stringify([]))
+    }
+    return new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 })
+  })
+}
+
+function renderPage(date = '2024-06-15') {
+  return render(
+    <MemoryRouter initialEntries={[`/log/${date}`]}>
+      <Routes>
+        <Route path="/log/:date" element={<DailyLogPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('DailyLogPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('renders date navigator', async () => {
+    mockFetch()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText(/Jun/)).toBeInTheDocument()
+    })
+  })
+
+  it('renders section headers', async () => {
+    mockFetch()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Caffeine')).toBeInTheDocument()
+    })
+    expect(screen.getByText('Meals')).toBeInTheDocument()
+    expect(screen.getByText('Supplements')).toBeInTheDocument()
+    expect(screen.getByText('Habits')).toBeInTheDocument()
+  })
+
+  it('shows save button', async () => {
+    mockFetch()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeInTheDocument()
+    })
+  })
+
+  it('calls PUT on save', async () => {
+    mockFetch()
+    const user = userEvent.setup()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Save')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Save'))
+    await waitFor(() => {
+      const calls = vi.mocked(globalThis.fetch).mock.calls
+      const putCall = calls.find(([, init]) => init && (init as RequestInit).method === 'PUT')
+      expect(putCall).toBeDefined()
+    })
+  })
+
+  it('shows loading initially', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}))
+    renderPage()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+
+  it('renders copy day button', async () => {
+    mockFetch()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('Copy from another day')).toBeInTheDocument()
+    })
+  })
+
+  it('renders notes textarea', async () => {
+    mockFetch()
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Any other notes about today...')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/DailyLog/DailyLogPage.tsx
+++ b/frontend/src/components/DailyLog/DailyLogPage.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from 'react'
+import { useDateNavigation } from '../../hooks/useDateNavigation'
+import { useDailyLog } from '../../hooks/useDailyLog'
+import { useCaffeineDecay } from '../../hooks/useCaffeineDecay'
+import { getSettings } from '../../api/settings'
+import type { UserSettingsOut, DailyLogCreate, DailyLogOut } from '../../types'
+import { DateNavigator } from './DateNavigator'
+import { CopyDayButton } from './CopyDayButton'
+import { WarningBanner } from './WarningBanner'
+import { CaffeineSection } from './sections/CaffeineSection'
+import { MealSection } from './sections/MealSection'
+import { SupplementSection } from './sections/SupplementSection'
+import { HabitSection } from './sections/HabitSection'
+import { StimulatingSection } from './sections/StimulatingSection'
+import { SexualActivitySection } from './sections/SexualActivitySection'
+import { PreBedRitualSection } from './sections/PreBedRitualSection'
+import { NapSection } from './sections/NapSection'
+import { SunlightSection } from './sections/SunlightSection'
+import { RedLightSection } from './sections/RedLightSection'
+import { NSDRSection } from './sections/NSDRSection'
+import { CaffeineChart } from '../CaffeineChart/CaffeineChart'
+import './DailyLogPage.css'
+
+/** Strip id/date from a DailyLogOut to get form data after a copy. */
+function outToCreate(out: DailyLogOut): DailyLogCreate {
+  return {
+    is_sick: out.is_sick,
+    notes: out.notes,
+    caffeine_entries: out.caffeine_entries.map(({ time, amount_mg, source }) => ({ time, amount_mg, source })),
+    meal_entries: out.meal_entries.map(({ time, is_last_meal, notes }) => ({ time, is_last_meal, notes })),
+    supplement_entries: out.supplement_entries.map(({ time, name, dose_mg }) => ({ time, name, dose_mg })),
+    habit_entries: out.habit_entries.map(({ habit_type, time, value, duration_minutes, notes }) => ({ habit_type, time, value, duration_minutes, notes })),
+    stimulating_activity_entries: out.stimulating_activity_entries.map(({ end_time, activity_type, duration_minutes }) => ({ end_time, activity_type, duration_minutes })),
+    sexual_activity_entry: out.sexual_activity_entry ? { time: out.sexual_activity_entry.time, activity_type: out.sexual_activity_entry.activity_type } : null,
+    pre_bed_ritual_entries: out.pre_bed_ritual_entries.map(({ time, ritual_type, duration_minutes }) => ({ time, ritual_type, duration_minutes })),
+    nap_entries: out.nap_entries.map(({ start_time, end_time, duration_minutes }) => ({ start_time, end_time, duration_minutes })),
+    sunlight_entries: out.sunlight_entries.map(({ start_time, duration_minutes, estimated_lux, notes }) => ({ start_time, duration_minutes, estimated_lux, notes })),
+    red_light_entries: out.red_light_entries.map(({ panel_id, start_time, duration_minutes }) => ({ panel_id, start_time, duration_minutes })),
+    nsdr_entries: out.nsdr_entries.map(({ time, duration_minutes, nsdr_type }) => ({ time, duration_minutes, nsdr_type })),
+  }
+}
+
+export function DailyLogPage() {
+  const { currentDate, isToday, prev, next, today } = useDateNavigation()
+  const { formData, setFormData, warnings, setWarnings, loading, saving, save } =
+    useDailyLog(currentDate)
+  const [settings, setSettings] = useState<UserSettingsOut | null>(null)
+
+  useEffect(() => {
+    getSettings().then(setSettings).catch(() => {})
+  }, [])
+
+  const caffeinePoints = useCaffeineDecay(
+    formData.caffeine_entries,
+    settings?.caffeine_sensitivity ?? 'normal',
+  )
+
+  const bedtimeHour = settings?.typical_bedtime
+    ? Number(settings.typical_bedtime.split(':')[0]) + Number(settings.typical_bedtime.split(':')[1]) / 60
+    : null
+
+  const update = <K extends keyof DailyLogCreate>(key: K, value: DailyLogCreate[K]) => {
+    setFormData((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const handleCopied = (log: DailyLogOut) => {
+    setFormData(outToCreate(log))
+  }
+
+  if (loading) {
+    return <div style={{ color: 'var(--color-text-muted)', padding: '2rem', textAlign: 'center' }}>Loading...</div>
+  }
+
+  return (
+    <div className="daily-log-page">
+      <DateNavigator
+        date={currentDate}
+        isToday={isToday}
+        onPrev={prev}
+        onNext={next}
+        onToday={today}
+      />
+
+      <WarningBanner warnings={warnings} onDismiss={() => setWarnings([])} />
+
+      <div className="daily-log-actions">
+        <CopyDayButton targetDate={currentDate} onCopied={handleCopied} />
+        <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>
+            <input
+              type="checkbox"
+              checked={formData.is_sick ?? false}
+              onChange={(e) => update('is_sick', e.target.checked || null)}
+            />
+            Sick day
+          </label>
+        </div>
+      </div>
+
+      <div className="daily-log-sections">
+        <CaffeineSection
+          entries={formData.caffeine_entries}
+          onChange={(v) => update('caffeine_entries', v)}
+        />
+
+        {formData.caffeine_entries.length > 0 && (
+          <CaffeineChart points={caffeinePoints} bedtimeHour={bedtimeHour} />
+        )}
+
+        <MealSection
+          entries={formData.meal_entries}
+          onChange={(v) => update('meal_entries', v)}
+        />
+
+        <SupplementSection
+          entries={formData.supplement_entries}
+          onChange={(v) => update('supplement_entries', v)}
+        />
+
+        <HabitSection
+          entries={formData.habit_entries}
+          onChange={(v) => update('habit_entries', v)}
+        />
+
+        <StimulatingSection
+          entries={formData.stimulating_activity_entries}
+          onChange={(v) => update('stimulating_activity_entries', v)}
+        />
+
+        <SexualActivitySection
+          entry={formData.sexual_activity_entry}
+          onChange={(v) => update('sexual_activity_entry', v)}
+        />
+
+        <PreBedRitualSection
+          entries={formData.pre_bed_ritual_entries}
+          onChange={(v) => update('pre_bed_ritual_entries', v)}
+        />
+
+        <NapSection
+          entries={formData.nap_entries}
+          onChange={(v) => update('nap_entries', v)}
+        />
+
+        <SunlightSection
+          entries={formData.sunlight_entries}
+          onChange={(v) => update('sunlight_entries', v)}
+        />
+
+        <RedLightSection
+          entries={formData.red_light_entries}
+          onChange={(v) => update('red_light_entries', v)}
+        />
+
+        <NSDRSection
+          entries={formData.nsdr_entries}
+          onChange={(v) => update('nsdr_entries', v)}
+        />
+      </div>
+
+      <div className="daily-log-notes">
+        <label style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>Notes</label>
+        <textarea
+          value={formData.notes ?? ''}
+          onChange={(e) => update('notes', e.target.value || null)}
+          placeholder="Any other notes about today..."
+          rows={3}
+          style={{ width: '100%', resize: 'vertical' }}
+        />
+      </div>
+
+      <div className="daily-log-save">
+        <button type="button" onClick={save} disabled={saving} className="daily-log-save-btn">
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/DailyLog/DateNavigator.css
+++ b/frontend/src/components/DailyLog/DateNavigator.css
@@ -1,0 +1,49 @@
+.date-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.date-nav-arrow {
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border-light);
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 1.2rem;
+}
+
+.date-nav-center {
+  flex: 1;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.date-nav-date {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.date-nav-today-badge {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: var(--color-interactive);
+  color: var(--color-bg-primary);
+}
+
+.date-nav-today-btn {
+  font-size: 0.85rem;
+  padding: 6px 12px;
+  background: transparent;
+  color: var(--color-text-accent);
+  border: 1px solid var(--color-border-light);
+}

--- a/frontend/src/components/DailyLog/DateNavigator.test.tsx
+++ b/frontend/src/components/DailyLog/DateNavigator.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { DateNavigator } from './DateNavigator'
+
+describe('DateNavigator', () => {
+  it('displays formatted date', () => {
+    render(
+      <DateNavigator date="2024-06-15" isToday={false} onPrev={vi.fn()} onNext={vi.fn()} onToday={vi.fn()} />,
+    )
+    expect(screen.getByText(/Jun 15/)).toBeInTheDocument()
+  })
+
+  it('shows Today badge when isToday', () => {
+    render(
+      <DateNavigator date="2024-06-15" isToday onPrev={vi.fn()} onNext={vi.fn()} onToday={vi.fn()} />,
+    )
+    expect(screen.getByText('Today')).toBeInTheDocument()
+  })
+
+  it('shows Today button when not today', () => {
+    render(
+      <DateNavigator date="2024-06-14" isToday={false} onPrev={vi.fn()} onNext={vi.fn()} onToday={vi.fn()} />,
+    )
+    // The Today button (not badge)
+    const buttons = screen.getAllByRole('button')
+    expect(buttons.some((b) => b.textContent === 'Today')).toBe(true)
+  })
+
+  it('calls onPrev when left arrow clicked', async () => {
+    const onPrev = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <DateNavigator date="2024-06-15" isToday={false} onPrev={onPrev} onNext={vi.fn()} onToday={vi.fn()} />,
+    )
+    await user.click(screen.getByLabelText('Previous day'))
+    expect(onPrev).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNext when right arrow clicked', async () => {
+    const onNext = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <DateNavigator date="2024-06-15" isToday={false} onPrev={vi.fn()} onNext={onNext} onToday={vi.fn()} />,
+    )
+    await user.click(screen.getByLabelText('Next day'))
+    expect(onNext).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/DailyLog/DateNavigator.tsx
+++ b/frontend/src/components/DailyLog/DateNavigator.tsx
@@ -1,0 +1,41 @@
+import './DateNavigator.css'
+
+interface DateNavigatorProps {
+  date: string
+  isToday: boolean
+  onPrev: () => void
+  onNext: () => void
+  onToday: () => void
+}
+
+function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T12:00:00')
+  return d.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  })
+}
+
+export function DateNavigator({ date, isToday, onPrev, onNext, onToday }: DateNavigatorProps) {
+  return (
+    <div className="date-nav">
+      <button type="button" className="date-nav-arrow" onClick={onPrev} aria-label="Previous day">
+        &larr;
+      </button>
+      <div className="date-nav-center">
+        <span className="date-nav-date">{formatDate(date)}</span>
+        {isToday && <span className="date-nav-today-badge">Today</span>}
+      </div>
+      <button type="button" className="date-nav-arrow" onClick={onNext} aria-label="Next day">
+        &rarr;
+      </button>
+      {!isToday && (
+        <button type="button" className="date-nav-today-btn" onClick={onToday}>
+          Today
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/DailyLog/WarningBanner.css
+++ b/frontend/src/components/DailyLog/WarningBanner.css
@@ -1,0 +1,30 @@
+.warning-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+  border: 1px solid var(--color-warning);
+  border-radius: 8px;
+  background: var(--color-bg-elevated);
+}
+
+.warning-banner-content {
+  flex: 1;
+  color: var(--color-warning);
+  font-size: 0.9rem;
+}
+
+.warning-banner-content p {
+  margin: 0.25rem 0;
+}
+
+.warning-banner-dismiss {
+  background: transparent;
+  color: var(--color-warning);
+  border: none;
+  font-size: 1.2rem;
+  padding: 0 4px;
+  cursor: pointer;
+  line-height: 1;
+}

--- a/frontend/src/components/DailyLog/WarningBanner.test.tsx
+++ b/frontend/src/components/DailyLog/WarningBanner.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { WarningBanner } from './WarningBanner'
+
+describe('WarningBanner', () => {
+  it('renders nothing when no warnings', () => {
+    const { container } = render(<WarningBanner warnings={[]} onDismiss={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders warning messages', () => {
+    render(<WarningBanner warnings={['Late caffeine', 'High stress']} onDismiss={vi.fn()} />)
+    expect(screen.getByText('Late caffeine')).toBeInTheDocument()
+    expect(screen.getByText('High stress')).toBeInTheDocument()
+  })
+
+  it('has alert role', () => {
+    render(<WarningBanner warnings={['Test']} onDismiss={vi.fn()} />)
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('calls onDismiss when dismiss clicked', async () => {
+    const onDismiss = vi.fn()
+    const user = userEvent.setup()
+    render(<WarningBanner warnings={['Test']} onDismiss={onDismiss} />)
+    await user.click(screen.getByLabelText('Dismiss warnings'))
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+})

--- a/frontend/src/components/DailyLog/WarningBanner.tsx
+++ b/frontend/src/components/DailyLog/WarningBanner.tsx
@@ -1,0 +1,23 @@
+import './WarningBanner.css'
+
+interface WarningBannerProps {
+  warnings: string[]
+  onDismiss: () => void
+}
+
+export function WarningBanner({ warnings, onDismiss }: WarningBannerProps) {
+  if (warnings.length === 0) return null
+
+  return (
+    <div className="warning-banner" role="alert">
+      <div className="warning-banner-content">
+        {warnings.map((w, i) => (
+          <p key={i}>{w}</p>
+        ))}
+      </div>
+      <button type="button" className="warning-banner-dismiss" onClick={onDismiss} aria-label="Dismiss warnings">
+        &times;
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/CaffeineSection.css
+++ b/frontend/src/components/DailyLog/sections/CaffeineSection.css
@@ -1,0 +1,44 @@
+.caffeine-quick-add {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.caffeine-quick-btn {
+  font-size: 0.8rem;
+  padding: 4px 10px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-accent);
+  border: 1px solid var(--color-border-light);
+}
+
+.caffeine-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg-secondary);
+}
+
+.caffeine-remove {
+  align-self: flex-end;
+  font-size: 0.8rem;
+  background: transparent;
+  color: var(--color-error);
+  border: none;
+  padding: 4px 8px;
+}
+
+.caffeine-total {
+  color: var(--color-text-secondary);
+  font-size: 0.9rem;
+}
+
+.caffeine-add-custom {
+  background: transparent;
+  color: var(--color-text-accent);
+  border: 1px dashed var(--color-border-light);
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/DailyLog/sections/CaffeineSection.test.tsx
+++ b/frontend/src/components/DailyLog/sections/CaffeineSection.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { CaffeineSection } from './CaffeineSection'
+
+describe('CaffeineSection', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    // Default section to open
+    localStorage.setItem('somnus-section-caffeine', 'true')
+  })
+
+  it('renders quick-add buttons', () => {
+    render(<CaffeineSection entries={[]} onChange={vi.fn()} />)
+    expect(screen.getByText('+ Espresso (63mg)')).toBeInTheDocument()
+    expect(screen.getByText('+ Coffee (95mg)')).toBeInTheDocument()
+    expect(screen.getByText('+ Tea (47mg)')).toBeInTheDocument()
+  })
+
+  it('adds entry on quick-add click', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<CaffeineSection entries={[]} onChange={onChange} />)
+    await user.click(screen.getByText('+ Coffee (95mg)'))
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ amount_mg: 95, source: 'drip_coffee' }),
+      ]),
+    )
+  })
+
+  it('shows total when entries exist', () => {
+    render(
+      <CaffeineSection
+        entries={[
+          { time: '08:00:00', amount_mg: 95, source: 'drip_coffee' },
+          { time: '14:00:00', amount_mg: 63, source: 'espresso' },
+        ]}
+        onChange={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('158mg')).toBeInTheDocument()
+  })
+
+  it('removes entry on remove click', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <CaffeineSection
+        entries={[{ time: '08:00:00', amount_mg: 95, source: 'drip_coffee' }]}
+        onChange={onChange}
+      />,
+    )
+    await user.click(screen.getByText('Remove'))
+    expect(onChange).toHaveBeenCalledWith([])
+  })
+
+  it('renders add custom entry button', () => {
+    render(<CaffeineSection entries={[]} onChange={vi.fn()} />)
+    expect(screen.getByText('+ Add custom entry')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/DailyLog/sections/CaffeineSection.tsx
+++ b/frontend/src/components/DailyLog/sections/CaffeineSection.tsx
@@ -1,0 +1,96 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import { SelectInput } from '../../shared/SelectInput'
+import {
+  CaffeineSource,
+  CAFFEINE_SOURCE_LABELS,
+} from '../../../types/enums'
+import type { CaffeineEntryCreate } from '../../../types'
+import './CaffeineSection.css'
+
+interface CaffeineSectionProps {
+  entries: CaffeineEntryCreate[]
+  onChange: (entries: CaffeineEntryCreate[]) => void
+}
+
+const QUICK_ADD: { label: string; mg: number; source: CaffeineSource }[] = [
+  { label: 'Espresso (63mg)', mg: 63, source: CaffeineSource.ESPRESSO },
+  { label: 'Coffee (95mg)', mg: 95, source: CaffeineSource.DRIP_COFFEE },
+  { label: 'Tea (47mg)', mg: 47, source: CaffeineSource.TEA },
+]
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function CaffeineSection({ entries, onChange }: CaffeineSectionProps) {
+  const totalMg = entries.reduce((sum, e) => sum + e.amount_mg, 0)
+
+  const addEntry = (entry: CaffeineEntryCreate) => onChange([...entries, entry])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: CaffeineEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Caffeine" count={entries.length} storageKey="caffeine" defaultOpen>
+      <div className="caffeine-quick-add">
+        {QUICK_ADD.map((qa) => (
+          <button
+            key={qa.source}
+            type="button"
+            className="caffeine-quick-btn"
+            onClick={() => addEntry({ time: nowTimeStr(), amount_mg: qa.mg, source: qa.source })}
+          >
+            + {qa.label}
+          </button>
+        ))}
+      </div>
+
+      {entries.map((entry, i) => (
+        <div key={i} className="caffeine-entry">
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+          <NumberInput
+            label="Amount"
+            value={entry.amount_mg}
+            onChange={(v) => updateEntry(i, { ...entry, amount_mg: v ?? 0 })}
+            unit="mg"
+            min={1}
+            max={600}
+          />
+          <SelectInput
+            label="Source"
+            value={entry.source}
+            onChange={(v) => updateEntry(i, { ...entry, source: v })}
+            options={Object.values(CaffeineSource)}
+            labels={CAFFEINE_SOURCE_LABELS}
+          />
+          <button type="button" className="caffeine-remove" onClick={() => removeEntry(i)}>
+            Remove
+          </button>
+        </div>
+      ))}
+
+      {totalMg > 0 && (
+        <p className="caffeine-total">
+          Total: <strong>{totalMg}mg</strong>
+        </p>
+      )}
+
+      <button
+        type="button"
+        className="caffeine-add-custom"
+        onClick={() =>
+          addEntry({ time: nowTimeStr(), amount_mg: 95, source: CaffeineSource.OTHER })
+        }
+      >
+        + Add custom entry
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/HabitSection.tsx
+++ b/frontend/src/components/DailyLog/sections/HabitSection.tsx
@@ -1,0 +1,161 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import { SelectInput } from '../../shared/SelectInput'
+import { SliderInput } from '../../shared/SliderInput'
+import {
+  HabitType,
+  HABIT_TYPE_LABELS,
+  ExerciseIntensity,
+} from '../../../types/enums'
+import type { HabitEntryCreate } from '../../../types'
+
+interface HabitSectionProps {
+  entries: HabitEntryCreate[]
+  onChange: (entries: HabitEntryCreate[]) => void
+}
+
+const EXERCISE_LABELS: Record<string, string> = {
+  light: 'Light',
+  moderate: 'Moderate',
+  intense: 'Intense',
+}
+
+export function HabitSection({ entries, onChange }: HabitSectionProps) {
+  const addEntry = (habitType: HabitType) =>
+    onChange([
+      ...entries,
+      { habit_type: habitType, time: null, value: null, duration_minutes: null, notes: null },
+    ])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: HabitEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  const usedTypes = new Set(entries.map((e) => e.habit_type))
+
+  const renderFields = (entry: HabitEntryCreate, i: number) => {
+    switch (entry.habit_type) {
+      case HabitType.EXERCISE:
+        return (
+          <>
+            <SelectInput
+              label="Intensity"
+              value={(entry.value as string) ?? ExerciseIntensity.MODERATE}
+              onChange={(v) => updateEntry(i, { ...entry, value: v })}
+              options={Object.values(ExerciseIntensity)}
+              labels={EXERCISE_LABELS}
+            />
+            <NumberInput
+              label="Duration"
+              value={entry.duration_minutes}
+              onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+              unit="min"
+              min={1}
+              max={300}
+            />
+            <TimePicker
+              label="Time"
+              value={entry.time}
+              onChange={(v) => updateEntry(i, { ...entry, time: v })}
+            />
+          </>
+        )
+      case HabitType.ALCOHOL:
+        return (
+          <>
+            <NumberInput
+              label="Drinks"
+              value={entry.value ? Number(entry.value) : null}
+              onChange={(v) => updateEntry(i, { ...entry, value: v != null ? String(v) : null })}
+              min={1}
+              max={20}
+            />
+            <TimePicker
+              label="Last drink time"
+              value={entry.time}
+              onChange={(v) => updateEntry(i, { ...entry, time: v })}
+            />
+          </>
+        )
+      case HabitType.ROOM_TEMP_F:
+        return (
+          <NumberInput
+            label="Temperature"
+            value={entry.value ? Number(entry.value) : null}
+            onChange={(v) => updateEntry(i, { ...entry, value: v != null ? String(v) : null })}
+            unit="°F"
+            min={55}
+            max={85}
+          />
+        )
+      case HabitType.STRESS_LEVEL:
+        return (
+          <SliderInput
+            label="Stress Level"
+            value={entry.value ? Number(entry.value) : null}
+            onChange={(v) => updateEntry(i, { ...entry, value: v != null ? String(v) : null })}
+            min={1}
+            max={5}
+            labels={['Very Low', 'Low', 'Medium', 'High', 'Very High']}
+          />
+        )
+      case HabitType.SAUNA:
+      case HabitType.WARM_SHOWER:
+        return (
+          <>
+            <NumberInput
+              label="Duration"
+              value={entry.duration_minutes}
+              onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+              unit="min"
+              min={1}
+            />
+            <TimePicker
+              label="Time"
+              value={entry.time}
+              onChange={(v) => updateEntry(i, { ...entry, time: v })}
+            />
+          </>
+        )
+      default:
+        return (
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+        )
+    }
+  }
+
+  return (
+    <SectionWrapper title="Habits" count={entries.length} storageKey="habits">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+        {Object.values(HabitType)
+          .filter((ht) => !usedTypes.has(ht) || ht === HabitType.EXERCISE)
+          .map((ht) => (
+            <button
+              key={ht}
+              type="button"
+              onClick={() => addEntry(ht)}
+              style={{ fontSize: '0.8rem', padding: '4px 10px', background: 'var(--color-bg-elevated)', color: 'var(--color-text-accent)', border: '1px solid var(--color-border-light)', borderRadius: '6px', cursor: 'pointer' }}
+            >
+              + {HABIT_TYPE_LABELS[ht]}
+            </button>
+          ))}
+      </div>
+
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <strong style={{ color: 'var(--color-text-secondary)', fontSize: '0.9rem' }}>
+            {HABIT_TYPE_LABELS[entry.habit_type]}
+          </strong>
+          {renderFields(entry, i)}
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/MealSection.tsx
+++ b/frontend/src/components/DailyLog/sections/MealSection.tsx
@@ -1,0 +1,52 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { Toggle } from '../../shared/Toggle'
+import type { MealEntryCreate } from '../../../types'
+
+interface MealSectionProps {
+  entries: MealEntryCreate[]
+  onChange: (entries: MealEntryCreate[]) => void
+}
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function MealSection({ entries, onChange }: MealSectionProps) {
+  const addEntry = () =>
+    onChange([...entries, { time: nowTimeStr(), is_last_meal: null, notes: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: MealEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Meals" count={entries.length} storageKey="meals">
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+          <Toggle
+            label="Last meal of the day"
+            checked={entry.is_last_meal}
+            onChange={(v) => updateEntry(i, { ...entry, is_last_meal: v })}
+          />
+          <input
+            placeholder="Notes (optional)"
+            value={entry.notes ?? ''}
+            onChange={(e) => updateEntry(i, { ...entry, notes: e.target.value || null })}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addEntry} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem' }}>
+        + Add meal
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/NSDRSection.tsx
+++ b/frontend/src/components/DailyLog/sections/NSDRSection.tsx
@@ -1,0 +1,58 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { SelectInput } from '../../shared/SelectInput'
+import { NSDRType, NSDR_TYPE_LABELS } from '../../../types/enums'
+import type { NSDREntryCreate } from '../../../types'
+
+interface NSDRSectionProps {
+  entries: NSDREntryCreate[]
+  onChange: (entries: NSDREntryCreate[]) => void
+}
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function NSDRSection({ entries, onChange }: NSDRSectionProps) {
+  const addQuick = (minutes: number) =>
+    onChange([...entries, { time: nowTimeStr(), duration_minutes: minutes, nsdr_type: NSDRType.YOGA_NIDRA }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: NSDREntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="NSDR" count={entries.length} storageKey="nsdr">
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        {[10, 20, 30].map((min) => (
+          <button key={min} type="button" onClick={() => addQuick(min)} style={{ fontSize: '0.8rem', padding: '4px 10px', background: 'var(--color-bg-elevated)', color: 'var(--color-text-accent)', border: '1px solid var(--color-border-light)', borderRadius: '6px', cursor: 'pointer' }}>
+            + {min} min
+          </button>
+        ))}
+      </div>
+
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <SelectInput
+            label="Type"
+            value={entry.nsdr_type}
+            onChange={(v) => updateEntry(i, { ...entry, nsdr_type: v })}
+            options={Object.values(NSDRType)}
+            labels={NSDR_TYPE_LABELS}
+          />
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+          <p style={{ fontSize: '0.85rem', color: 'var(--color-text-muted)' }}>
+            Duration: {entry.duration_minutes ?? '—'} min
+          </p>
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/NapSection.tsx
+++ b/frontend/src/components/DailyLog/sections/NapSection.tsx
@@ -1,0 +1,61 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import type { NapEntryCreate } from '../../../types'
+
+interface NapSectionProps {
+  entries: NapEntryCreate[]
+  onChange: (entries: NapEntryCreate[]) => void
+}
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function NapSection({ entries, onChange }: NapSectionProps) {
+  const addQuickNap = (minutes: number) =>
+    onChange([...entries, { start_time: nowTimeStr(), end_time: null, duration_minutes: minutes }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: NapEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Naps" count={entries.length} storageKey="naps">
+      <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <button type="button" onClick={() => addQuickNap(20)} style={{ fontSize: '0.8rem', padding: '4px 10px', background: 'var(--color-bg-elevated)', color: 'var(--color-text-accent)', border: '1px solid var(--color-border-light)', borderRadius: '6px', cursor: 'pointer' }}>
+          + 20 min nap
+        </button>
+        <button type="button" onClick={() => addQuickNap(90)} style={{ fontSize: '0.8rem', padding: '4px 10px', background: 'var(--color-bg-elevated)', color: 'var(--color-text-accent)', border: '1px solid var(--color-border-light)', borderRadius: '6px', cursor: 'pointer' }}>
+          + 90 min nap
+        </button>
+      </div>
+
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <TimePicker
+            label="Start Time"
+            value={entry.start_time}
+            onChange={(v) => updateEntry(i, { ...entry, start_time: v })}
+          />
+          <TimePicker
+            label="End Time"
+            value={entry.end_time}
+            onChange={(v) => updateEntry(i, { ...entry, end_time: v })}
+          />
+          <NumberInput
+            label="Duration"
+            value={entry.duration_minutes}
+            onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+            unit="min"
+            min={1}
+            max={240}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/PreBedRitualSection.tsx
+++ b/frontend/src/components/DailyLog/sections/PreBedRitualSection.tsx
@@ -1,0 +1,56 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import { SelectInput } from '../../shared/SelectInput'
+import {
+  PreBedRitualType,
+  PRE_BED_RITUAL_LABELS,
+} from '../../../types/enums'
+import type { PreBedRitualCreate } from '../../../types'
+
+interface PreBedRitualSectionProps {
+  entries: PreBedRitualCreate[]
+  onChange: (entries: PreBedRitualCreate[]) => void
+}
+
+export function PreBedRitualSection({ entries, onChange }: PreBedRitualSectionProps) {
+  const addEntry = () =>
+    onChange([...entries, { time: null, ritual_type: PreBedRitualType.DEEP_BREATHING, duration_minutes: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: PreBedRitualCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Pre-Bed Rituals" count={entries.length} storageKey="rituals">
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <SelectInput
+            label="Type"
+            value={entry.ritual_type}
+            onChange={(v) => updateEntry(i, { ...entry, ritual_type: v })}
+            options={Object.values(PreBedRitualType)}
+            labels={PRE_BED_RITUAL_LABELS}
+          />
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+          <NumberInput
+            label="Duration"
+            value={entry.duration_minutes}
+            onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+            unit="min"
+            min={1}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addEntry} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+        + Add ritual
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/RedLightSection.tsx
+++ b/frontend/src/components/DailyLog/sections/RedLightSection.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import { listPanels, type RedLightPanelOut } from '../../../api/redLightPanels'
+import type { RedLightEntryCreate } from '../../../types'
+
+interface RedLightSectionProps {
+  entries: RedLightEntryCreate[]
+  onChange: (entries: RedLightEntryCreate[]) => void
+}
+
+export function RedLightSection({ entries, onChange }: RedLightSectionProps) {
+  const [panels, setPanels] = useState<RedLightPanelOut[]>([])
+
+  useEffect(() => {
+    listPanels().then(setPanels).catch(() => {})
+  }, [])
+
+  const addEntry = () =>
+    onChange([...entries, { panel_id: panels[0]?.id ?? null, start_time: null, duration_minutes: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: RedLightEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  const getDose = (entry: RedLightEntryCreate): string | null => {
+    if (!entry.panel_id || !entry.duration_minutes) return null
+    const panel = panels.find((p) => p.id === entry.panel_id)
+    if (!panel?.irradiance_mw_cm2) return null
+    const joules = panel.irradiance_mw_cm2 * entry.duration_minutes * 60 / 1000
+    return `${joules.toFixed(2)} J/cm²`
+  }
+
+  return (
+    <SectionWrapper title="Red Light Therapy" count={entries.length} storageKey="redLight">
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          {panels.length > 0 && (
+            <div>
+              <label style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>Panel</label>
+              <select
+                value={entry.panel_id ?? ''}
+                onChange={(e) => updateEntry(i, { ...entry, panel_id: e.target.value ? Number(e.target.value) : null })}
+                style={{ width: '100%' }}
+              >
+                <option value="">No panel</option>
+                {panels.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            </div>
+          )}
+          <TimePicker
+            label="Start Time"
+            value={entry.start_time}
+            onChange={(v) => updateEntry(i, { ...entry, start_time: v })}
+          />
+          <NumberInput
+            label="Duration"
+            value={entry.duration_minutes}
+            onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+            unit="min"
+            min={1}
+            max={60}
+          />
+          {getDose(entry) && (
+            <p style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem' }}>
+              Dose: {getDose(entry)}
+            </p>
+          )}
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addEntry} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+        + Add session
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/SectionWrapper.css
+++ b/frontend/src/components/DailyLog/sections/SectionWrapper.css
@@ -1,0 +1,51 @@
+.section-wrapper {
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: var(--color-bg-secondary);
+  color: var(--color-text-primary);
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  text-align: left;
+}
+
+.section-header:hover {
+  background: var(--color-bg-elevated);
+}
+
+.section-arrow {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  width: 1rem;
+}
+
+.section-title {
+  flex: 1;
+}
+
+.section-count {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background-color: var(--color-interactive);
+  color: var(--color-bg-primary);
+}
+
+.section-content {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-top: 1px solid var(--color-border);
+}

--- a/frontend/src/components/DailyLog/sections/SectionWrapper.test.tsx
+++ b/frontend/src/components/DailyLog/sections/SectionWrapper.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { SectionWrapper } from './SectionWrapper'
+
+describe('SectionWrapper', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders title', () => {
+    render(
+      <SectionWrapper title="Caffeine" storageKey="test">
+        <p>Content</p>
+      </SectionWrapper>,
+    )
+    expect(screen.getByText('Caffeine')).toBeInTheDocument()
+  })
+
+  it('shows count badge when count > 0', () => {
+    render(
+      <SectionWrapper title="Caffeine" count={3} storageKey="test">
+        <p>Content</p>
+      </SectionWrapper>,
+    )
+    expect(screen.getByText('3')).toBeInTheDocument()
+  })
+
+  it('hides content by default when defaultOpen is false', () => {
+    render(
+      <SectionWrapper title="Caffeine" storageKey="test" defaultOpen={false}>
+        <p>Hidden content</p>
+      </SectionWrapper>,
+    )
+    expect(screen.queryByText('Hidden content')).not.toBeInTheDocument()
+  })
+
+  it('shows content when defaultOpen is true', () => {
+    render(
+      <SectionWrapper title="Caffeine" storageKey="test" defaultOpen>
+        <p>Visible content</p>
+      </SectionWrapper>,
+    )
+    expect(screen.getByText('Visible content')).toBeInTheDocument()
+  })
+
+  it('toggles on click', async () => {
+    const user = userEvent.setup()
+    render(
+      <SectionWrapper title="Caffeine" storageKey="test" defaultOpen={false}>
+        <p>Toggle me</p>
+      </SectionWrapper>,
+    )
+    expect(screen.queryByText('Toggle me')).not.toBeInTheDocument()
+    await user.click(screen.getByText('Caffeine'))
+    expect(screen.getByText('Toggle me')).toBeInTheDocument()
+    await user.click(screen.getByText('Caffeine'))
+    expect(screen.queryByText('Toggle me')).not.toBeInTheDocument()
+  })
+
+  it('persists state in localStorage', async () => {
+    const user = userEvent.setup()
+    render(
+      <SectionWrapper title="Caffeine" storageKey="persist-test" defaultOpen={false}>
+        <p>Content</p>
+      </SectionWrapper>,
+    )
+    await user.click(screen.getByText('Caffeine'))
+    expect(localStorage.getItem('somnus-section-persist-test')).toBe('true')
+  })
+})

--- a/frontend/src/components/DailyLog/sections/SectionWrapper.tsx
+++ b/frontend/src/components/DailyLog/sections/SectionWrapper.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import './SectionWrapper.css'
+
+interface SectionWrapperProps {
+  title: string
+  count?: number
+  storageKey: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+}
+
+export function SectionWrapper({
+  title,
+  count,
+  storageKey,
+  defaultOpen = false,
+  children,
+}: SectionWrapperProps) {
+  const [open, setOpen] = useState(() => {
+    const stored = localStorage.getItem(`somnus-section-${storageKey}`)
+    if (stored !== null) return stored === 'true'
+    return defaultOpen
+  })
+
+  const toggle = () => {
+    const next = !open
+    setOpen(next)
+    localStorage.setItem(`somnus-section-${storageKey}`, String(next))
+  }
+
+  return (
+    <section className="section-wrapper">
+      <button type="button" className="section-header" onClick={toggle} aria-expanded={open}>
+        <span className="section-arrow">{open ? '\u25BE' : '\u25B8'}</span>
+        <span className="section-title">{title}</span>
+        {count != null && count > 0 && <span className="section-count">{count}</span>}
+      </button>
+      {open && <div className="section-content">{children}</div>}
+    </section>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/SexualActivitySection.tsx
+++ b/frontend/src/components/DailyLog/sections/SexualActivitySection.tsx
@@ -1,0 +1,45 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { SelectInput } from '../../shared/SelectInput'
+import {
+  SexualActivityType,
+  SEXUAL_ACTIVITY_LABELS,
+} from '../../../types/enums'
+import type { SexualActivityCreate } from '../../../types'
+
+interface SexualActivitySectionProps {
+  entry: SexualActivityCreate | null
+  onChange: (entry: SexualActivityCreate | null) => void
+}
+
+export function SexualActivitySection({ entry, onChange }: SexualActivitySectionProps) {
+  const count = entry ? 1 : 0
+
+  return (
+    <SectionWrapper title="Sexual Activity" count={count} storageKey="sexual-activity">
+      {entry ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+          <SelectInput
+            label="Type"
+            value={entry.activity_type}
+            onChange={(v) => onChange({ ...entry, activity_type: v })}
+            options={Object.values(SexualActivityType)}
+            labels={SEXUAL_ACTIVITY_LABELS}
+          />
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => onChange({ ...entry, time: v })}
+          />
+          <button type="button" onClick={() => onChange(null)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ) : (
+        <button type="button" onClick={() => onChange({ time: null, activity_type: SexualActivityType.PARTNERED })} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+          + Record
+        </button>
+      )}
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/StimulatingSection.tsx
+++ b/frontend/src/components/DailyLog/sections/StimulatingSection.tsx
@@ -1,0 +1,56 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import { SelectInput } from '../../shared/SelectInput'
+import {
+  StimulatingActivityType,
+  STIMULATING_ACTIVITY_LABELS,
+} from '../../../types/enums'
+import type { StimulatingActivityCreate } from '../../../types'
+
+interface StimulatingSectionProps {
+  entries: StimulatingActivityCreate[]
+  onChange: (entries: StimulatingActivityCreate[]) => void
+}
+
+export function StimulatingSection({ entries, onChange }: StimulatingSectionProps) {
+  const addEntry = () =>
+    onChange([...entries, { end_time: null, activity_type: StimulatingActivityType.TV_MOVIES, duration_minutes: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: StimulatingActivityCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Stimulating Activities" count={entries.length} storageKey="stimulating">
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <SelectInput
+            label="Type"
+            value={entry.activity_type}
+            onChange={(v) => updateEntry(i, { ...entry, activity_type: v })}
+            options={Object.values(StimulatingActivityType)}
+            labels={STIMULATING_ACTIVITY_LABELS}
+          />
+          <TimePicker
+            label="End Time"
+            value={entry.end_time}
+            onChange={(v) => updateEntry(i, { ...entry, end_time: v })}
+          />
+          <NumberInput
+            label="Duration"
+            value={entry.duration_minutes}
+            onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+            unit="min"
+            min={1}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addEntry} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+        + Add activity
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/SunlightSection.tsx
+++ b/frontend/src/components/DailyLog/sections/SunlightSection.tsx
@@ -1,0 +1,55 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import type { SunlightEntryCreate } from '../../../types'
+
+interface SunlightSectionProps {
+  entries: SunlightEntryCreate[]
+  onChange: (entries: SunlightEntryCreate[]) => void
+}
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function SunlightSection({ entries, onChange }: SunlightSectionProps) {
+  const addEntry = () =>
+    onChange([...entries, { start_time: nowTimeStr(), duration_minutes: null, estimated_lux: null, notes: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: SunlightEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Sunlight" count={entries.length} storageKey="sunlight">
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <TimePicker
+            label="Start Time"
+            value={entry.start_time}
+            onChange={(v) => updateEntry(i, { ...entry, start_time: v })}
+          />
+          <NumberInput
+            label="Duration"
+            value={entry.duration_minutes}
+            onChange={(v) => updateEntry(i, { ...entry, duration_minutes: v })}
+            unit="min"
+            min={1}
+          />
+          <NumberInput
+            label="Estimated Lux"
+            value={entry.estimated_lux}
+            onChange={(v) => updateEntry(i, { ...entry, estimated_lux: v })}
+            min={0}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+      <button type="button" onClick={addEntry} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+        + Add sunlight exposure
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/DailyLog/sections/SupplementSection.tsx
+++ b/frontend/src/components/DailyLog/sections/SupplementSection.tsx
@@ -1,0 +1,68 @@
+import { SectionWrapper } from './SectionWrapper'
+import { TimePicker } from '../../shared/TimePicker'
+import { NumberInput } from '../../shared/NumberInput'
+import type { SupplementEntryCreate } from '../../../types'
+
+interface SupplementSectionProps {
+  entries: SupplementEntryCreate[]
+  onChange: (entries: SupplementEntryCreate[]) => void
+}
+
+const COMMON_SUPPLEMENTS = ['Magnesium', 'Melatonin', 'L-Theanine', 'Glycine', 'Apigenin', 'Vitamin D']
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function SupplementSection({ entries, onChange }: SupplementSectionProps) {
+  const addEntry = (name: string = '') =>
+    onChange([...entries, { time: nowTimeStr(), name, dose_mg: null }])
+  const removeEntry = (index: number) => onChange(entries.filter((_, i) => i !== index))
+  const updateEntry = (index: number, updated: SupplementEntryCreate) =>
+    onChange(entries.map((e, i) => (i === index ? updated : e)))
+
+  return (
+    <SectionWrapper title="Supplements" count={entries.length} storageKey="supplements">
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+        {COMMON_SUPPLEMENTS.map((name) => (
+          <button key={name} type="button" onClick={() => addEntry(name)} style={{ fontSize: '0.8rem', padding: '4px 10px', background: 'var(--color-bg-elevated)', color: 'var(--color-text-accent)', border: '1px solid var(--color-border-light)', borderRadius: '6px', cursor: 'pointer' }}>
+            + {name}
+          </button>
+        ))}
+      </div>
+
+      {entries.map((entry, i) => (
+        <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', padding: '0.75rem', border: '1px solid var(--color-border)', borderRadius: '6px' }}>
+          <div>
+            <label style={{ fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>Name</label>
+            <input
+              value={entry.name}
+              onChange={(e) => updateEntry(i, { ...entry, name: e.target.value })}
+              style={{ width: '100%' }}
+            />
+          </div>
+          <NumberInput
+            label="Dose"
+            value={entry.dose_mg}
+            onChange={(v) => updateEntry(i, { ...entry, dose_mg: v })}
+            unit="mg"
+            min={0}
+          />
+          <TimePicker
+            label="Time"
+            value={entry.time}
+            onChange={(v) => updateEntry(i, { ...entry, time: v })}
+          />
+          <button type="button" onClick={() => removeEntry(i)} style={{ alignSelf: 'flex-end', background: 'transparent', color: 'var(--color-error)', border: 'none', fontSize: '0.8rem' }}>
+            Remove
+          </button>
+        </div>
+      ))}
+
+      <button type="button" onClick={() => addEntry()} style={{ background: 'transparent', color: 'var(--color-text-accent)', border: '1px dashed var(--color-border-light)', fontSize: '0.85rem', padding: '8px 16px', borderRadius: '6px', cursor: 'pointer' }}>
+        + Add custom supplement
+      </button>
+    </SectionWrapper>
+  )
+}

--- a/frontend/src/components/Layout/Layout.css
+++ b/frontend/src/components/Layout/Layout.css
@@ -1,0 +1,30 @@
+.layout {
+  min-height: 100vh;
+}
+
+.layout-header {
+  padding: 1rem 2rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.layout-title {
+  cursor: pointer;
+  font-size: 1.5rem;
+  color: var(--color-text-primary);
+  user-select: none;
+}
+
+.layout-main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+}
+
+.layout-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  color: var(--color-text-muted);
+  font-size: 1.2rem;
+}

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+import { Outlet, useNavigate, useLocation } from 'react-router-dom'
+import { getSettings } from '../../api/settings'
+import type { UserSettingsOut } from '../../types'
+import './Layout.css'
+
+export function Layout() {
+  const [settings, setSettings] = useState<UserSettingsOut | null>(null)
+  const [loading, setLoading] = useState(true)
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  useEffect(() => {
+    getSettings()
+      .then(setSettings)
+      .catch(() => {
+        // Settings not available yet — treat as needing onboarding
+        setSettings(null)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    if (loading || !settings) return
+
+    const onOnboarding = location.pathname.startsWith('/onboarding')
+
+    if (!settings.onboarding_completed && !onOnboarding) {
+      navigate('/onboarding', { replace: true })
+    } else if (settings.onboarding_completed && onOnboarding) {
+      navigate('/log', { replace: true })
+    }
+  }, [settings, loading, location.pathname, navigate])
+
+  if (loading) {
+    return (
+      <div className="layout">
+        <div className="layout-loading">Loading...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="layout">
+      <header className="layout-header">
+        <h1 className="layout-title" onClick={() => navigate('/log')} role="button" tabIndex={0}>
+          Somnus
+        </h1>
+      </header>
+      <main className="layout-main">
+        <Outlet />
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/DataStorageStep.tsx
+++ b/frontend/src/components/Onboarding/DataStorageStep.tsx
@@ -1,0 +1,27 @@
+import { StepNavigation } from './StepNavigation'
+
+interface DataStorageStepProps {
+  onNext: () => void
+  onBack: () => void
+}
+
+export function DataStorageStep({ onNext, onBack }: DataStorageStepProps) {
+  return (
+    <div>
+      <h2>Your Data Stays Local</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        All your sleep and health data is stored locally on your machine. Nothing is sent to
+        external servers.
+      </p>
+
+      <ul style={{ color: 'var(--color-text-secondary)', paddingLeft: '1.5rem', lineHeight: 2 }}>
+        <li>Data stored in a local SQLite database</li>
+        <li>Export your data anytime as JSON</li>
+        <li>No cloud accounts required</li>
+        <li>Oura data fetched directly to your machine</li>
+      </ul>
+
+      <StepNavigation isFirst={false} isLast={false} onBack={onBack} onNext={onNext} />
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/DoneStep.tsx
+++ b/frontend/src/components/Onboarding/DoneStep.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router-dom'
+import type { UserSettingsUpdate } from '../../types'
+
+interface DoneStepProps {
+  onUpdate: (data: UserSettingsUpdate) => void
+}
+
+export function DoneStep({ onUpdate }: DoneStepProps) {
+  const navigate = useNavigate()
+
+  const handleFinish = async () => {
+    await onUpdate({ onboarding_completed: true })
+    navigate('/log', { replace: true })
+  }
+
+  return (
+    <div>
+      <h2>You&apos;re All Set!</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        Start logging your day to discover what helps you sleep better.
+      </p>
+
+      <ul style={{ color: 'var(--color-text-secondary)', paddingLeft: '1.5rem', lineHeight: 2 }}>
+        <li>Log caffeine, meals, and habits throughout the day</li>
+        <li>Review your sleep data each morning</li>
+        <li>After 7+ days, check the dashboard for insights</li>
+      </ul>
+
+      <button
+        type="button"
+        onClick={handleFinish}
+        style={{ marginTop: '1.5rem', width: '100%', padding: '12px' }}
+      >
+        Start Logging
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/OnboardingWizard.css
+++ b/frontend/src/components/Onboarding/OnboardingWizard.css
@@ -1,0 +1,29 @@
+.onboarding {
+  max-width: 500px;
+  margin: 2rem auto;
+}
+
+.onboarding-progress {
+  height: 4px;
+  background-color: var(--color-bg-elevated);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 2rem;
+}
+
+.onboarding-progress-bar {
+  height: 100%;
+  background-color: var(--color-interactive);
+  transition: width 0.3s ease;
+}
+
+.onboarding-step {
+  min-height: 300px;
+}
+
+.onboarding-hint {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  margin-top: 1rem;
+}

--- a/frontend/src/components/Onboarding/OnboardingWizard.test.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import { OnboardingWizard } from './OnboardingWizard'
+
+const mockSettings = {
+  oura_token_set: false,
+  typical_bedtime: null,
+  target_wake_time: null,
+  caffeine_sensitivity: 'normal',
+  timezone: 'America/New_York',
+  chronotype: null,
+  zip_code: null,
+  age: null,
+  display_mode: 'circadian',
+  circadian_mode_start: '20:00:00',
+  onboarding_completed: false,
+}
+
+function mockFetchResponses() {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(async (url, init) => {
+    const urlStr = typeof url === 'string' ? url : url.toString()
+    if (urlStr === '/api/settings' && (!init || init.method === undefined)) {
+      return new Response(JSON.stringify(mockSettings))
+    }
+    if (urlStr === '/api/settings' && init?.method === 'PATCH') {
+      const body = JSON.parse(init.body as string)
+      return new Response(JSON.stringify({ ...mockSettings, ...body }))
+    }
+    return new Response(JSON.stringify({}), { status: 404 })
+  })
+}
+
+function renderWizard() {
+  return render(
+    <MemoryRouter initialEntries={['/onboarding']}>
+      <OnboardingWizard />
+    </MemoryRouter>,
+  )
+}
+
+describe('OnboardingWizard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('renders welcome step first', async () => {
+    mockFetchResponses()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+  })
+
+  it('shows progress bar', async () => {
+    mockFetchResponses()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+    expect(document.querySelector('.onboarding-progress-bar')).toBeInTheDocument()
+  })
+
+  it('navigates to next step on Get Started click', async () => {
+    mockFetchResponses()
+    const user = userEvent.setup()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Get Started'))
+    expect(screen.getByText('Oura Ring Integration')).toBeInTheDocument()
+  })
+
+  it('can navigate back from Oura step', async () => {
+    mockFetchResponses()
+    const user = userEvent.setup()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Get Started'))
+    await user.click(screen.getByText('Back'))
+    expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+  })
+
+  it('can skip Oura step', async () => {
+    mockFetchResponses()
+    const user = userEvent.setup()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+    await user.click(screen.getByText('Get Started'))
+    await user.click(screen.getByText('Skip'))
+    expect(screen.getByText('Sleep Profile')).toBeInTheDocument()
+  })
+
+  it('reaches done step after all navigation', async () => {
+    mockFetchResponses()
+    const user = userEvent.setup()
+    renderWizard()
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+    // Welcome → Oura
+    await user.click(screen.getByText('Get Started'))
+    // Oura → Sleep Profile
+    await user.click(screen.getByText('Skip'))
+    // Sleep Profile → Tracking Setup
+    await user.click(screen.getByText('Next'))
+    // Tracking Setup → Data Storage
+    await user.click(screen.getByText('Next'))
+    // Data Storage → Done
+    await user.click(screen.getByText('Next'))
+    expect(screen.getByText("You're All Set!")).toBeInTheDocument()
+  })
+
+  it('shows loading state while fetching settings', () => {
+    vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}))
+    renderWizard()
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/Onboarding/OnboardingWizard.tsx
+++ b/frontend/src/components/Onboarding/OnboardingWizard.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useOnboarding } from '../../hooks/useOnboarding'
+import { getSettings, updateSettings } from '../../api/settings'
+import type { UserSettingsOut, UserSettingsUpdate } from '../../types'
+import { WelcomeStep } from './WelcomeStep'
+import { OuraStep } from './OuraStep'
+import { SleepProfileStep } from './SleepProfileStep'
+import { TrackingSetupStep } from './TrackingSetupStep'
+import { DataStorageStep } from './DataStorageStep'
+import { DoneStep } from './DoneStep'
+import './OnboardingWizard.css'
+
+export function OnboardingWizard() {
+  const { step, progress, isFirst, isLast, next, back } = useOnboarding()
+  const [settings, setSettings] = useState<UserSettingsOut | null>(null)
+
+  useEffect(() => {
+    getSettings().then(setSettings).catch(() => {})
+  }, [])
+
+  const handleUpdate = useCallback(async (data: UserSettingsUpdate) => {
+    const updated = await updateSettings(data)
+    setSettings(updated)
+    return updated
+  }, [])
+
+  if (!settings) {
+    return <div style={{ color: 'var(--color-text-muted)' }}>Loading...</div>
+  }
+
+  const renderStep = () => {
+    switch (step) {
+      case 'welcome':
+        return (
+          <WelcomeStep
+            age={settings.age}
+            timezone={settings.timezone}
+            onUpdate={handleUpdate}
+            onNext={next}
+          />
+        )
+      case 'oura':
+        return (
+          <OuraStep
+            ouraTokenSet={settings.oura_token_set}
+            onUpdate={handleUpdate}
+            onNext={next}
+            onBack={back}
+          />
+        )
+      case 'sleep-profile':
+        return (
+          <SleepProfileStep
+            typicalBedtime={settings.typical_bedtime}
+            targetWakeTime={settings.target_wake_time}
+            caffeineSensitivity={settings.caffeine_sensitivity}
+            chronotype={settings.chronotype}
+            onUpdate={handleUpdate}
+            onNext={next}
+            onBack={back}
+          />
+        )
+      case 'tracking-setup':
+        return <TrackingSetupStep onNext={next} onBack={back} />
+      case 'data-storage':
+        return <DataStorageStep onNext={next} onBack={back} />
+      case 'done':
+        return <DoneStep onUpdate={handleUpdate} />
+    }
+  }
+
+  return (
+    <div className="onboarding">
+      <div className="onboarding-progress">
+        <div className="onboarding-progress-bar" style={{ width: `${progress}%` }} />
+      </div>
+      <div className="onboarding-step">{renderStep()}</div>
+      {!isFirst && !isLast && (
+        <p className="onboarding-hint">
+          Step {Math.round(progress / (100 / 6))} of 6
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/OuraStep.tsx
+++ b/frontend/src/components/Onboarding/OuraStep.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import { StepNavigation } from './StepNavigation'
+import type { UserSettingsUpdate } from '../../types'
+
+interface OuraStepProps {
+  ouraTokenSet: boolean
+  onUpdate: (data: UserSettingsUpdate) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function OuraStep({ ouraTokenSet, onUpdate, onNext, onBack }: OuraStepProps) {
+  const [token, setToken] = useState('')
+
+  const handleSave = () => {
+    if (token.trim()) {
+      onUpdate({ oura_token: token.trim() })
+    }
+    onNext()
+  }
+
+  return (
+    <div>
+      <h2>Oura Ring Integration</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        Connect your Oura Ring to automatically import sleep data. You can always add this later.
+      </p>
+
+      {ouraTokenSet ? (
+        <p style={{ color: 'var(--color-success)' }}>Oura token is already configured.</p>
+      ) : (
+        <div>
+          <label style={{ display: 'block', marginBottom: '0.25rem', fontSize: '0.85rem', color: 'var(--color-text-secondary)' }}>
+            Personal Access Token
+          </label>
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="Paste your Oura token"
+            style={{ width: '100%' }}
+          />
+        </div>
+      )}
+
+      <StepNavigation
+        isFirst={false}
+        isLast={false}
+        onBack={onBack}
+        onNext={handleSave}
+        onSkip={onNext}
+        nextLabel={token.trim() ? 'Save & Continue' : 'Next'}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/SleepProfileStep.tsx
+++ b/frontend/src/components/Onboarding/SleepProfileStep.tsx
@@ -1,0 +1,68 @@
+import { TimePicker } from '../shared/TimePicker'
+import { SelectInput } from '../shared/SelectInput'
+import { StepNavigation } from './StepNavigation'
+import {
+  CaffeineSensitivity,
+  CAFFEINE_SENSITIVITY_LABELS,
+  Chronotype,
+  CHRONOTYPE_LABELS,
+} from '../../types/enums'
+import type { UserSettingsUpdate } from '../../types'
+
+interface SleepProfileStepProps {
+  typicalBedtime: string | null
+  targetWakeTime: string | null
+  caffeineSensitivity: CaffeineSensitivity
+  chronotype: Chronotype | null
+  onUpdate: (data: UserSettingsUpdate) => void
+  onNext: () => void
+  onBack: () => void
+}
+
+export function SleepProfileStep({
+  typicalBedtime,
+  targetWakeTime,
+  caffeineSensitivity,
+  chronotype,
+  onUpdate,
+  onNext,
+  onBack,
+}: SleepProfileStepProps) {
+  return (
+    <div>
+      <h2>Sleep Profile</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        Help us understand your sleep patterns.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <TimePicker
+          label="Typical Bedtime"
+          value={typicalBedtime}
+          onChange={(v) => onUpdate({ typical_bedtime: v })}
+        />
+        <TimePicker
+          label="Target Wake Time"
+          value={targetWakeTime}
+          onChange={(v) => onUpdate({ target_wake_time: v })}
+        />
+        <SelectInput
+          label="Caffeine Sensitivity"
+          value={caffeineSensitivity}
+          onChange={(v) => onUpdate({ caffeine_sensitivity: v })}
+          options={Object.values(CaffeineSensitivity)}
+          labels={CAFFEINE_SENSITIVITY_LABELS}
+        />
+        <SelectInput
+          label="Chronotype"
+          value={chronotype ?? Chronotype.INTERMEDIATE}
+          onChange={(v) => onUpdate({ chronotype: v })}
+          options={Object.values(Chronotype)}
+          labels={CHRONOTYPE_LABELS}
+        />
+      </div>
+
+      <StepNavigation isFirst={false} isLast={false} onBack={onBack} onNext={onNext} />
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/StepNavigation.css
+++ b/frontend/src/components/Onboarding/StepNavigation.css
@@ -1,0 +1,29 @@
+.step-nav {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.step-nav-spacer {
+  flex: 1;
+}
+
+.step-nav-back {
+  background: transparent;
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-light);
+}
+
+.step-nav-skip {
+  background: transparent;
+  color: var(--color-text-muted);
+  border: none;
+  text-decoration: underline;
+}
+
+.step-nav-next {
+  min-width: 100px;
+}

--- a/frontend/src/components/Onboarding/StepNavigation.tsx
+++ b/frontend/src/components/Onboarding/StepNavigation.tsx
@@ -1,0 +1,40 @@
+import './StepNavigation.css'
+
+interface StepNavigationProps {
+  isFirst: boolean
+  isLast: boolean
+  onBack: () => void
+  onNext: () => void
+  onSkip?: () => void
+  nextLabel?: string
+}
+
+export function StepNavigation({
+  isFirst,
+  isLast,
+  onBack,
+  onNext,
+  onSkip,
+  nextLabel,
+}: StepNavigationProps) {
+  return (
+    <div className="step-nav">
+      {!isFirst && (
+        <button type="button" className="step-nav-back" onClick={onBack}>
+          Back
+        </button>
+      )}
+      <div className="step-nav-spacer" />
+      {onSkip && (
+        <button type="button" className="step-nav-skip" onClick={onSkip}>
+          Skip
+        </button>
+      )}
+      {!isLast && (
+        <button type="button" className="step-nav-next" onClick={onNext}>
+          {nextLabel ?? 'Next'}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/TrackingSetupStep.tsx
+++ b/frontend/src/components/Onboarding/TrackingSetupStep.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react'
+import { Toggle } from '../shared/Toggle'
+import { StepNavigation } from './StepNavigation'
+
+const TRACKING_ITEMS = [
+  { key: 'caffeine', label: 'Caffeine intake' },
+  { key: 'meals', label: 'Meal timing' },
+  { key: 'supplements', label: 'Supplements' },
+  { key: 'exercise', label: 'Exercise' },
+  { key: 'sunlight', label: 'Sunlight exposure' },
+  { key: 'naps', label: 'Naps' },
+  { key: 'stress', label: 'Stress level' },
+  { key: 'alcohol', label: 'Alcohol' },
+  { key: 'screens', label: 'Screen time before bed' },
+  { key: 'rituals', label: 'Pre-bed rituals' },
+  { key: 'redLight', label: 'Red light therapy' },
+  { key: 'nsdr', label: 'NSDR / Yoga Nidra' },
+] as const
+
+interface TrackingSetupStepProps {
+  onNext: () => void
+  onBack: () => void
+}
+
+export function TrackingSetupStep({ onNext, onBack }: TrackingSetupStepProps) {
+  const [selected, setSelected] = useState<Set<string>>(() => {
+    const stored = localStorage.getItem('somnus-tracked-sections')
+    if (stored) return new Set(JSON.parse(stored) as string[])
+    // Default: most items on
+    return new Set(TRACKING_ITEMS.map((i) => i.key))
+  })
+
+  const toggle = (key: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  const handleNext = () => {
+    localStorage.setItem('somnus-tracked-sections', JSON.stringify([...selected]))
+    onNext()
+  }
+
+  return (
+    <div>
+      <h2>What do you want to track?</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        Choose which items appear in your daily log. You can change this anytime.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}>
+        {TRACKING_ITEMS.map((item) => (
+          <Toggle
+            key={item.key}
+            label={item.label}
+            checked={selected.has(item.key)}
+            onChange={() => toggle(item.key)}
+          />
+        ))}
+      </div>
+
+      <StepNavigation isFirst={false} isLast={false} onBack={onBack} onNext={handleNext} />
+    </div>
+  )
+}

--- a/frontend/src/components/Onboarding/WelcomeStep.tsx
+++ b/frontend/src/components/Onboarding/WelcomeStep.tsx
@@ -1,0 +1,67 @@
+import { NumberInput } from '../shared/NumberInput'
+import { SelectInput } from '../shared/SelectInput'
+import { StepNavigation } from './StepNavigation'
+import type { UserSettingsUpdate } from '../../types'
+
+const TIMEZONES = [
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Anchorage',
+  'Pacific/Honolulu',
+  'Europe/London',
+  'Europe/Berlin',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+] as const
+
+const TIMEZONE_LABELS: Record<string, string> = {
+  'America/New_York': 'Eastern (US)',
+  'America/Chicago': 'Central (US)',
+  'America/Denver': 'Mountain (US)',
+  'America/Los_Angeles': 'Pacific (US)',
+  'America/Anchorage': 'Alaska',
+  'Pacific/Honolulu': 'Hawaii',
+  'Europe/London': 'London',
+  'Europe/Berlin': 'Berlin',
+  'Asia/Tokyo': 'Tokyo',
+  'Australia/Sydney': 'Sydney',
+}
+
+interface WelcomeStepProps {
+  age: number | null
+  timezone: string
+  onUpdate: (data: UserSettingsUpdate) => void
+  onNext: () => void
+}
+
+export function WelcomeStep({ age, timezone, onUpdate, onNext }: WelcomeStepProps) {
+  return (
+    <div>
+      <h2>Welcome to Somnus</h2>
+      <p style={{ color: 'var(--color-text-secondary)', margin: '0.5rem 0 1.5rem' }}>
+        Let&apos;s set up your sleep optimization profile. This takes about 2 minutes.
+      </p>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+        <NumberInput
+          label="Age"
+          value={age}
+          onChange={(v) => onUpdate({ age: v })}
+          min={1}
+          max={120}
+        />
+        <SelectInput
+          label="Timezone"
+          value={timezone}
+          onChange={(v) => onUpdate({ timezone: v })}
+          options={[...TIMEZONES]}
+          labels={TIMEZONE_LABELS}
+        />
+      </div>
+
+      <StepNavigation isFirst isLast={false} onBack={() => {}} onNext={onNext} nextLabel="Get Started" />
+    </div>
+  )
+}

--- a/frontend/src/components/shared/NumberInput.tsx
+++ b/frontend/src/components/shared/NumberInput.tsx
@@ -1,0 +1,29 @@
+interface NumberInputProps {
+  label: string
+  value: number | null
+  onChange: (value: number | null) => void
+  unit?: string
+  min?: number
+  max?: number
+  step?: number
+}
+
+export function NumberInput({ label, value, onChange, unit, min, max, step }: NumberInputProps) {
+  return (
+    <div className="number-input">
+      <label className="number-input-label">{label}</label>
+      <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+        <input
+          type="number"
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value === '' ? null : Number(e.target.value))}
+          min={min}
+          max={max}
+          step={step}
+          style={{ flex: 1 }}
+        />
+        {unit && <span style={{ color: 'var(--color-text-muted)', fontSize: '0.85rem' }}>{unit}</span>}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/SelectInput.tsx
+++ b/frontend/src/components/shared/SelectInput.tsx
@@ -1,0 +1,28 @@
+interface SelectInputProps<T extends string> {
+  label: string
+  value: T
+  onChange: (value: T) => void
+  options: readonly T[]
+  labels: Record<T, string>
+}
+
+export function SelectInput<T extends string>({
+  label,
+  value,
+  onChange,
+  options,
+  labels,
+}: SelectInputProps<T>) {
+  return (
+    <div className="select-input">
+      <label className="select-input-label">{label}</label>
+      <select value={value} onChange={(e) => onChange(e.target.value as T)}>
+        {options.map((opt) => (
+          <option key={opt} value={opt}>
+            {labels[opt]}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/SliderInput.tsx
+++ b/frontend/src/components/shared/SliderInput.tsx
@@ -1,0 +1,39 @@
+interface SliderInputProps {
+  label: string
+  value: number | null
+  onChange: (value: number | null) => void
+  min?: number
+  max?: number
+  step?: number
+  labels?: string[]
+}
+
+export function SliderInput({
+  label,
+  value,
+  onChange,
+  min = 1,
+  max = 5,
+  step = 1,
+  labels,
+}: SliderInputProps) {
+  return (
+    <div className="slider-input">
+      <label className="slider-input-label">
+        {label}: {value ?? '—'}
+        {labels && value != null && value >= min && value <= max
+          ? ` (${labels[value - min]})`
+          : ''}
+      </label>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value ?? min}
+        onChange={(e) => onChange(Number(e.target.value))}
+        style={{ width: '100%', accentColor: 'var(--color-interactive)' }}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/shared/TimePicker.css
+++ b/frontend/src/components/shared/TimePicker.css
@@ -1,0 +1,25 @@
+.time-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.time-picker-label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+}
+
+.time-picker-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.time-picker-input {
+  flex: 1;
+}
+
+.time-picker-now {
+  padding: 6px 12px;
+  font-size: 0.85rem;
+}

--- a/frontend/src/components/shared/TimePicker.test.tsx
+++ b/frontend/src/components/shared/TimePicker.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { TimePicker } from './TimePicker'
+
+describe('TimePicker', () => {
+  it('renders label', () => {
+    render(<TimePicker label="Start Time" value={null} onChange={vi.fn()} />)
+    expect(screen.getByText('Start Time')).toBeInTheDocument()
+  })
+
+  it('renders Now button', () => {
+    render(<TimePicker label="Time" value={null} onChange={vi.fn()} />)
+    expect(screen.getByText('Now')).toBeInTheDocument()
+  })
+
+  it('calls onChange with current time on Now click', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<TimePicker label="Time" value={null} onChange={onChange} />)
+    await user.click(screen.getByText('Now'))
+    expect(onChange).toHaveBeenCalledWith(expect.stringMatching(/^\d{2}:\d{2}:00$/))
+  })
+
+  it('displays value in input', () => {
+    render(<TimePicker label="Time" value="14:30:00" onChange={vi.fn()} />)
+    const input = screen.getByDisplayValue('14:30')
+    expect(input).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/TimePicker.tsx
+++ b/frontend/src/components/shared/TimePicker.tsx
@@ -1,0 +1,31 @@
+import './TimePicker.css'
+
+interface TimePickerProps {
+  label: string
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+function nowTimeStr(): string {
+  const d = new Date()
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}:00`
+}
+
+export function TimePicker({ label, value, onChange }: TimePickerProps) {
+  return (
+    <div className="time-picker">
+      <label className="time-picker-label">{label}</label>
+      <div className="time-picker-row">
+        <input
+          type="time"
+          className="time-picker-input"
+          value={value?.slice(0, 5) ?? ''}
+          onChange={(e) => onChange(e.target.value ? `${e.target.value}:00` : null)}
+        />
+        <button type="button" className="time-picker-now" onClick={() => onChange(nowTimeStr())}>
+          Now
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/Toggle.css
+++ b/frontend/src/components/shared/Toggle.css
@@ -1,0 +1,43 @@
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+
+.toggle-label {
+  font-size: 0.9rem;
+  color: var(--color-text-secondary);
+}
+
+.toggle-track {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 12px;
+  background-color: var(--color-bg-elevated);
+  border: 1px solid var(--color-border-light);
+  cursor: pointer;
+  transition: background-color 0.2s;
+  padding: 0;
+}
+
+.toggle-track--on {
+  background-color: var(--color-interactive);
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: var(--color-text-primary);
+  transition: transform 0.2s;
+}
+
+.toggle-track--on .toggle-thumb {
+  transform: translateX(20px);
+}

--- a/frontend/src/components/shared/Toggle.tsx
+++ b/frontend/src/components/shared/Toggle.tsx
@@ -1,0 +1,24 @@
+import './Toggle.css'
+
+interface ToggleProps {
+  label: string
+  checked: boolean | null
+  onChange: (checked: boolean) => void
+}
+
+export function Toggle({ label, checked, onChange }: ToggleProps) {
+  return (
+    <label className="toggle">
+      <span className="toggle-label">{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked ?? false}
+        className={`toggle-track ${checked ? 'toggle-track--on' : ''}`}
+        onClick={() => onChange(!checked)}
+      >
+        <span className="toggle-thumb" />
+      </button>
+    </label>
+  )
+}

--- a/frontend/src/hooks/useCaffeineDecay.ts
+++ b/frontend/src/hooks/useCaffeineDecay.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import {
+  computeDecayCurve,
+  type CaffeineEntry,
+  type CaffeinePoint,
+} from '../components/CaffeineChart/caffeineCalc'
+import type { CaffeineSensitivity } from '../types/enums'
+
+export function useCaffeineDecay(
+  entries: CaffeineEntry[],
+  sensitivity: CaffeineSensitivity,
+): CaffeinePoint[] {
+  return useMemo(
+    () => computeDecayCurve(entries, sensitivity),
+    [entries, sensitivity],
+  )
+}

--- a/frontend/src/hooks/useDailyLog.ts
+++ b/frontend/src/hooks/useDailyLog.ts
@@ -1,0 +1,136 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getDailyLog, saveDailyLog } from '../api/dailyLog'
+import type { DailyLogCreate, DailyLogOut } from '../types'
+import { ApiError } from '../types/api'
+
+function emptyLog(): DailyLogCreate {
+  return {
+    is_sick: null,
+    notes: null,
+    caffeine_entries: [],
+    meal_entries: [],
+    supplement_entries: [],
+    habit_entries: [],
+    stimulating_activity_entries: [],
+    sexual_activity_entry: null,
+    pre_bed_ritual_entries: [],
+    nap_entries: [],
+    sunlight_entries: [],
+    red_light_entries: [],
+    nsdr_entries: [],
+  }
+}
+
+/** Strip `id` and `date` from Out entries to produce Create form state. */
+function outToCreate(out: DailyLogOut): DailyLogCreate {
+  return {
+    is_sick: out.is_sick,
+    notes: out.notes,
+    caffeine_entries: out.caffeine_entries.map(({ time, amount_mg, source }) => ({
+      time,
+      amount_mg,
+      source,
+    })),
+    meal_entries: out.meal_entries.map(({ time, is_last_meal, notes }) => ({
+      time,
+      is_last_meal,
+      notes,
+    })),
+    supplement_entries: out.supplement_entries.map(({ time, name, dose_mg }) => ({
+      time,
+      name,
+      dose_mg,
+    })),
+    habit_entries: out.habit_entries.map(
+      ({ habit_type, time, value, duration_minutes, notes }) => ({
+        habit_type,
+        time,
+        value,
+        duration_minutes,
+        notes,
+      }),
+    ),
+    stimulating_activity_entries: out.stimulating_activity_entries.map(
+      ({ end_time, activity_type, duration_minutes }) => ({
+        end_time,
+        activity_type,
+        duration_minutes,
+      }),
+    ),
+    sexual_activity_entry: out.sexual_activity_entry
+      ? { time: out.sexual_activity_entry.time, activity_type: out.sexual_activity_entry.activity_type }
+      : null,
+    pre_bed_ritual_entries: out.pre_bed_ritual_entries.map(
+      ({ time, ritual_type, duration_minutes }) => ({
+        time,
+        ritual_type,
+        duration_minutes,
+      }),
+    ),
+    nap_entries: out.nap_entries.map(({ start_time, end_time, duration_minutes }) => ({
+      start_time,
+      end_time,
+      duration_minutes,
+    })),
+    sunlight_entries: out.sunlight_entries.map(
+      ({ start_time, duration_minutes, estimated_lux, notes }) => ({
+        start_time,
+        duration_minutes,
+        estimated_lux,
+        notes,
+      }),
+    ),
+    red_light_entries: out.red_light_entries.map(
+      ({ panel_id, start_time, duration_minutes }) => ({
+        panel_id,
+        start_time,
+        duration_minutes,
+      }),
+    ),
+    nsdr_entries: out.nsdr_entries.map(({ time, duration_minutes, nsdr_type }) => ({
+      time,
+      duration_minutes,
+      nsdr_type,
+    })),
+  }
+}
+
+export function useDailyLog(date: string) {
+  const [formData, setFormData] = useState<DailyLogCreate>(emptyLog)
+  const [warnings, setWarnings] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [exists, setExists] = useState(false)
+
+  useEffect(() => {
+    setLoading(true)
+    setWarnings([])
+    getDailyLog(date)
+      .then((out) => {
+        setFormData(outToCreate(out))
+        setExists(true)
+      })
+      .catch((e: unknown) => {
+        if (e instanceof ApiError && e.status === 404) {
+          setFormData(emptyLog())
+          setExists(false)
+        }
+      })
+      .finally(() => setLoading(false))
+  }, [date])
+
+  const save = useCallback(async () => {
+    setSaving(true)
+    try {
+      const res = await saveDailyLog(date, formData)
+      setFormData(outToCreate(res.data))
+      setWarnings(res.warnings)
+      setExists(true)
+      return res
+    } finally {
+      setSaving(false)
+    }
+  }, [date, formData])
+
+  return { formData, setFormData, warnings, setWarnings, loading, saving, exists, save }
+}

--- a/frontend/src/hooks/useDateNavigation.ts
+++ b/frontend/src/hooks/useDateNavigation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function addDays(dateStr: string, days: number): string {
+  const d = new Date(dateStr + 'T12:00:00')
+  d.setDate(d.getDate() + days)
+  return d.toISOString().slice(0, 10)
+}
+
+export function useDateNavigation() {
+  const { date } = useParams<{ date: string }>()
+  const navigate = useNavigate()
+
+  const currentDate = date ?? todayStr()
+  const isToday = currentDate === todayStr()
+
+  const goTo = useCallback(
+    (d: string) => navigate(`/log/${d}`),
+    [navigate],
+  )
+  const prev = useCallback(() => goTo(addDays(currentDate, -1)), [currentDate, goTo])
+  const next = useCallback(() => goTo(addDays(currentDate, 1)), [currentDate, goTo])
+  const today = useCallback(() => goTo(todayStr()), [goTo])
+
+  return { currentDate, isToday, goTo, prev, next, today }
+}

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export const ONBOARDING_STEPS = [
+  'welcome',
+  'oura',
+  'sleep-profile',
+  'tracking-setup',
+  'data-storage',
+  'done',
+] as const
+
+export type OnboardingStep = (typeof ONBOARDING_STEPS)[number]
+
+export function useOnboarding() {
+  const [stepIndex, setStepIndex] = useState(0)
+
+  const step = ONBOARDING_STEPS[stepIndex]
+  const isFirst = stepIndex === 0
+  const isLast = stepIndex === ONBOARDING_STEPS.length - 1
+  const progress = ((stepIndex + 1) / ONBOARDING_STEPS.length) * 100
+
+  const next = () => setStepIndex((i) => Math.min(i + 1, ONBOARDING_STEPS.length - 1))
+  const back = () => setStepIndex((i) => Math.max(i - 1, 0))
+
+  return { step, stepIndex, isFirst, isLast, progress, next, back }
+}

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -1,0 +1,24 @@
+import { useCallback, useEffect, useState } from 'react'
+import { getSettings, updateSettings } from '../api/settings'
+import type { UserSettingsOut, UserSettingsUpdate } from '../types'
+
+export function useSettings() {
+  const [settings, setSettings] = useState<UserSettingsOut | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    getSettings()
+      .then(setSettings)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false))
+  }, [])
+
+  const update = useCallback(async (data: UserSettingsUpdate) => {
+    const updated = await updateSettings(data)
+    setSettings(updated)
+    return updated
+  }, [])
+
+  return { settings, loading, error, update }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { RouterProvider } from 'react-router-dom'
 import './index.css'
-import App from './App.tsx'
+import { router } from './router'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
 )

--- a/frontend/src/router.test.tsx
+++ b/frontend/src/router.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createMemoryRouter, RouterProvider } from 'react-router-dom'
+import { Layout } from './components/Layout/Layout'
+import { OnboardingWizard } from './components/Onboarding/OnboardingWizard'
+import { DailyLogPage } from './components/DailyLog/DailyLogPage'
+
+const mockSettingsOnboarded = {
+  oura_token_set: false,
+  typical_bedtime: null,
+  target_wake_time: null,
+  caffeine_sensitivity: 'normal',
+  timezone: 'America/New_York',
+  chronotype: null,
+  zip_code: null,
+  age: null,
+  display_mode: 'circadian',
+  circadian_mode_start: '20:00:00',
+  onboarding_completed: true,
+}
+
+const mockSettingsNotOnboarded = {
+  ...mockSettingsOnboarded,
+  onboarding_completed: false,
+}
+
+function createRouter(initialPath: string) {
+  return createMemoryRouter(
+    [
+      {
+        path: '/',
+        element: <Layout />,
+        children: [
+          { path: 'onboarding', element: <OnboardingWizard /> },
+          { path: 'log/:date', element: <DailyLogPage /> },
+        ],
+      },
+    ],
+    { initialEntries: [initialPath] },
+  )
+}
+
+describe('Router guard', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('redirects to onboarding when not completed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('/api/settings')) {
+        return new Response(JSON.stringify(mockSettingsNotOnboarded))
+      }
+      return new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 })
+    })
+
+    const router = createRouter('/log/2024-01-01')
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Welcome to Somnus')).toBeInTheDocument()
+    })
+  })
+
+  it('redirects to log when onboarding completed and on /onboarding', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('/api/settings')) {
+        return new Response(JSON.stringify(mockSettingsOnboarded))
+      }
+      if (urlStr.includes('/api/daily-log/')) {
+        return new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 })
+      }
+      if (urlStr.includes('/api/red-light-panels')) {
+        return new Response(JSON.stringify([]))
+      }
+      return new Response(JSON.stringify({}), { status: 200 })
+    })
+
+    const router = createRouter('/onboarding')
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      // Should redirect away from onboarding - should see daily log page elements
+      expect(screen.queryByText('Welcome to Somnus')).not.toBeInTheDocument()
+    })
+  })
+
+  it('shows layout header', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) => {
+      const urlStr = typeof url === 'string' ? url : url.toString()
+      if (urlStr.includes('/api/settings')) {
+        return new Response(JSON.stringify(mockSettingsOnboarded))
+      }
+      if (urlStr.includes('/api/daily-log/')) {
+        return new Response(JSON.stringify({ detail: 'Not found' }), { status: 404 })
+      }
+      if (urlStr.includes('/api/red-light-panels')) {
+        return new Response(JSON.stringify([]))
+      }
+      return new Response(JSON.stringify({}), { status: 200 })
+    })
+
+    const router = createRouter('/log/2024-01-01')
+    render(<RouterProvider router={router} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Somnus')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,0 +1,21 @@
+import { createBrowserRouter, Navigate } from 'react-router-dom'
+import { Layout } from './components/Layout/Layout'
+import { OnboardingWizard } from './components/Onboarding/OnboardingWizard'
+import { DailyLogPage } from './components/DailyLog/DailyLogPage'
+
+function todayStr(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Layout />,
+    children: [
+      { index: true, element: <Navigate to={`/log/${todayStr()}`} replace /> },
+      { path: 'onboarding', element: <OnboardingWizard /> },
+      { path: 'log', element: <Navigate to={`/log/${todayStr()}`} replace /> },
+      { path: 'log/:date', element: <DailyLogPage /> },
+    ],
+  },
+])

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,13 @@
+/** API error type for structured error handling. */
+
+export class ApiError extends Error {
+  status: number
+  detail: string
+
+  constructor(status: number, detail: string) {
+    super(detail)
+    this.name = 'ApiError'
+    this.status = status
+    this.detail = detail
+  }
+}

--- a/frontend/src/types/dailyLog.ts
+++ b/frontend/src/types/dailyLog.ts
@@ -1,0 +1,186 @@
+/** TypeScript interfaces mirroring backend schemas for daily log entries. */
+
+import type {
+  CaffeineSource,
+  HabitType,
+  NSDRType,
+  PreBedRitualType,
+  SexualActivityType,
+  StimulatingActivityType,
+} from './enums'
+
+// --- Entry Create types (for PUT body) ---
+
+export interface CaffeineEntryCreate {
+  time: string | null
+  amount_mg: number
+  source: CaffeineSource
+}
+
+export interface MealEntryCreate {
+  time: string | null
+  is_last_meal: boolean | null
+  notes: string | null
+}
+
+export interface SupplementEntryCreate {
+  time: string | null
+  name: string
+  dose_mg: number | null
+}
+
+export interface HabitEntryCreate {
+  habit_type: HabitType
+  time: string | null
+  value: string | null
+  duration_minutes: number | null
+  notes: string | null
+}
+
+export interface StimulatingActivityCreate {
+  end_time: string | null
+  activity_type: StimulatingActivityType
+  duration_minutes: number | null
+}
+
+export interface SexualActivityCreate {
+  time: string | null
+  activity_type: SexualActivityType
+}
+
+export interface PreBedRitualCreate {
+  time: string | null
+  ritual_type: PreBedRitualType
+  duration_minutes: number | null
+}
+
+export interface NapEntryCreate {
+  start_time: string | null
+  end_time: string | null
+  duration_minutes: number | null
+}
+
+export interface SunlightEntryCreate {
+  start_time: string | null
+  duration_minutes: number | null
+  estimated_lux: number | null
+  notes: string | null
+}
+
+export interface RedLightEntryCreate {
+  panel_id: number | null
+  start_time: string | null
+  duration_minutes: number | null
+}
+
+export interface NSDREntryCreate {
+  time: string | null
+  duration_minutes: number | null
+  nsdr_type: NSDRType
+}
+
+// --- Entry Out types (from GET response) ---
+
+export interface CaffeineEntryOut extends CaffeineEntryCreate {
+  id: number
+  date: string
+}
+
+export interface MealEntryOut extends MealEntryCreate {
+  id: number
+  date: string
+}
+
+export interface SupplementEntryOut extends SupplementEntryCreate {
+  id: number
+  date: string
+}
+
+export interface HabitEntryOut extends HabitEntryCreate {
+  id: number
+  date: string
+}
+
+export interface StimulatingActivityOut extends StimulatingActivityCreate {
+  id: number
+  date: string
+}
+
+export interface SexualActivityOut extends SexualActivityCreate {
+  id: number
+  date: string
+}
+
+export interface PreBedRitualOut extends PreBedRitualCreate {
+  id: number
+  date: string
+}
+
+export interface NapEntryOut extends NapEntryCreate {
+  id: number
+  date: string
+}
+
+export interface SunlightEntryOut extends SunlightEntryCreate {
+  id: number
+  date: string
+}
+
+export interface RedLightEntryOut extends RedLightEntryCreate {
+  id: number
+  date: string
+  dose_joules_cm2: number | null
+}
+
+export interface NSDREntryOut extends NSDREntryCreate {
+  id: number
+  date: string
+}
+
+// --- Composite daily log ---
+
+export interface DailyLogCreate {
+  is_sick: boolean | null
+  notes: string | null
+  caffeine_entries: CaffeineEntryCreate[]
+  meal_entries: MealEntryCreate[]
+  supplement_entries: SupplementEntryCreate[]
+  habit_entries: HabitEntryCreate[]
+  stimulating_activity_entries: StimulatingActivityCreate[]
+  sexual_activity_entry: SexualActivityCreate | null
+  pre_bed_ritual_entries: PreBedRitualCreate[]
+  nap_entries: NapEntryCreate[]
+  sunlight_entries: SunlightEntryCreate[]
+  red_light_entries: RedLightEntryCreate[]
+  nsdr_entries: NSDREntryCreate[]
+}
+
+export interface DailyLogOut {
+  date: string
+  copied_from_date: string | null
+  is_sick: boolean | null
+  notes: string | null
+  caffeine_entries: CaffeineEntryOut[]
+  meal_entries: MealEntryOut[]
+  supplement_entries: SupplementEntryOut[]
+  habit_entries: HabitEntryOut[]
+  stimulating_activity_entries: StimulatingActivityOut[]
+  sexual_activity_entry: SexualActivityOut | null
+  pre_bed_ritual_entries: PreBedRitualOut[]
+  nap_entries: NapEntryOut[]
+  sunlight_entries: SunlightEntryOut[]
+  red_light_entries: RedLightEntryOut[]
+  nsdr_entries: NSDREntryOut[]
+}
+
+export interface DailyLogResponse {
+  data: DailyLogOut
+  warnings: string[]
+}
+
+export interface DailyLogSummary {
+  date: string
+  copied_from_date: string | null
+  is_sick: boolean | null
+  has_entries: boolean
+}

--- a/frontend/src/types/enums.ts
+++ b/frontend/src/types/enums.ts
@@ -1,0 +1,152 @@
+/** Backend enums mirrored as TS const objects for runtime + compile-time use. */
+
+export const CaffeineSource = {
+  ESPRESSO: 'espresso',
+  DRIP_COFFEE: 'drip_coffee',
+  COLD_BREW: 'cold_brew',
+  TEA: 'tea',
+  ENERGY_DRINK: 'energy_drink',
+  SODA: 'soda',
+  SUPPLEMENT: 'supplement',
+  OTHER: 'other',
+} as const
+export type CaffeineSource = (typeof CaffeineSource)[keyof typeof CaffeineSource]
+
+export const CAFFEINE_SOURCE_LABELS: Record<CaffeineSource, string> = {
+  espresso: 'Espresso',
+  drip_coffee: 'Drip Coffee',
+  cold_brew: 'Cold Brew',
+  tea: 'Tea',
+  energy_drink: 'Energy Drink',
+  soda: 'Soda',
+  supplement: 'Supplement',
+  other: 'Other',
+}
+
+export const HabitType = {
+  BLUE_BLOCKERS_ON: 'blue_blockers_on',
+  SCREENS_OFF: 'screens_off',
+  EXERCISE: 'exercise',
+  ALCOHOL: 'alcohol',
+  ROOM_TEMP_F: 'room_temp_f',
+  STRESS_LEVEL: 'stress_level',
+  SAUNA: 'sauna',
+  WARM_SHOWER: 'warm_shower',
+} as const
+export type HabitType = (typeof HabitType)[keyof typeof HabitType]
+
+export const HABIT_TYPE_LABELS: Record<HabitType, string> = {
+  blue_blockers_on: 'Blue Blockers On',
+  screens_off: 'Screens Off',
+  exercise: 'Exercise',
+  alcohol: 'Alcohol',
+  room_temp_f: 'Room Temp (F)',
+  stress_level: 'Stress Level',
+  sauna: 'Sauna',
+  warm_shower: 'Warm Shower',
+}
+
+export const ExerciseIntensity = {
+  LIGHT: 'light',
+  MODERATE: 'moderate',
+  INTENSE: 'intense',
+} as const
+export type ExerciseIntensity = (typeof ExerciseIntensity)[keyof typeof ExerciseIntensity]
+
+export const StimulatingActivityType = {
+  TV_MOVIES: 'tv_movies',
+  VIDEO_GAMES: 'video_games',
+  GRIPPING_AUDIOBOOK: 'gripping_audiobook',
+  OTHER: 'other',
+} as const
+export type StimulatingActivityType =
+  (typeof StimulatingActivityType)[keyof typeof StimulatingActivityType]
+
+export const STIMULATING_ACTIVITY_LABELS: Record<StimulatingActivityType, string> = {
+  tv_movies: 'TV / Movies',
+  video_games: 'Video Games',
+  gripping_audiobook: 'Gripping Audiobook',
+  other: 'Other',
+}
+
+export const SexualActivityType = {
+  PARTNERED: 'partnered',
+  SOLO_WITH_CONTENT: 'solo_with_content',
+  SOLO_WITHOUT_CONTENT: 'solo_without_content',
+} as const
+export type SexualActivityType = (typeof SexualActivityType)[keyof typeof SexualActivityType]
+
+export const SEXUAL_ACTIVITY_LABELS: Record<SexualActivityType, string> = {
+  partnered: 'Partnered',
+  solo_with_content: 'Solo (with content)',
+  solo_without_content: 'Solo (without content)',
+}
+
+export const PreBedRitualType = {
+  DEEP_BREATHING: 'deep_breathing',
+  LEGS_UP_WALL: 'legs_up_wall',
+  STRETCHING: 'stretching',
+  JOURNALING: 'journaling',
+  READING_FICTION: 'reading_fiction',
+  OTHER: 'other',
+} as const
+export type PreBedRitualType = (typeof PreBedRitualType)[keyof typeof PreBedRitualType]
+
+export const PRE_BED_RITUAL_LABELS: Record<PreBedRitualType, string> = {
+  deep_breathing: 'Deep Breathing',
+  legs_up_wall: 'Legs Up Wall',
+  stretching: 'Stretching',
+  journaling: 'Journaling',
+  reading_fiction: 'Reading Fiction',
+  other: 'Other',
+}
+
+export const NSDRType = {
+  YOGA_NIDRA: 'yoga_nidra',
+  BODY_SCAN: 'body_scan',
+  SLEEP_HYPNOSIS: 'sleep_hypnosis',
+  GUIDED_RELAXATION: 'guided_relaxation',
+  OTHER: 'other',
+} as const
+export type NSDRType = (typeof NSDRType)[keyof typeof NSDRType]
+
+export const NSDR_TYPE_LABELS: Record<NSDRType, string> = {
+  yoga_nidra: 'Yoga Nidra',
+  body_scan: 'Body Scan',
+  sleep_hypnosis: 'Sleep Hypnosis',
+  guided_relaxation: 'Guided Relaxation',
+  other: 'Other',
+}
+
+export const CaffeineSensitivity = {
+  FAST: 'fast',
+  NORMAL: 'normal',
+  SLOW: 'slow',
+} as const
+export type CaffeineSensitivity = (typeof CaffeineSensitivity)[keyof typeof CaffeineSensitivity]
+
+export const CAFFEINE_SENSITIVITY_LABELS: Record<CaffeineSensitivity, string> = {
+  fast: 'Fast (2.5h half-life)',
+  normal: 'Normal (4h half-life)',
+  slow: 'Slow (6h half-life)',
+}
+
+export const Chronotype = {
+  EARLY: 'early',
+  INTERMEDIATE: 'intermediate',
+  LATE: 'late',
+} as const
+export type Chronotype = (typeof Chronotype)[keyof typeof Chronotype]
+
+export const CHRONOTYPE_LABELS: Record<Chronotype, string> = {
+  early: 'Early Bird',
+  intermediate: 'Intermediate',
+  late: 'Night Owl',
+}
+
+export const DisplayMode = {
+  CIRCADIAN: 'circadian',
+  LIGHT: 'light',
+  AUTO: 'auto',
+} as const
+export type DisplayMode = (typeof DisplayMode)[keyof typeof DisplayMode]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from './enums'
+export * from './dailyLog'
+export * from './settings'
+export * from './api'

--- a/frontend/src/types/settings.ts
+++ b/frontend/src/types/settings.ts
@@ -1,0 +1,31 @@
+/** TypeScript interfaces mirroring backend UserSettings schemas. */
+
+import type { CaffeineSensitivity, Chronotype, DisplayMode } from './enums'
+
+export interface UserSettingsOut {
+  oura_token_set: boolean
+  typical_bedtime: string | null
+  target_wake_time: string | null
+  caffeine_sensitivity: CaffeineSensitivity
+  timezone: string
+  chronotype: Chronotype | null
+  zip_code: string | null
+  age: number | null
+  display_mode: DisplayMode
+  circadian_mode_start: string
+  onboarding_completed: boolean
+}
+
+export interface UserSettingsUpdate {
+  oura_token?: string | null
+  typical_bedtime?: string | null
+  target_wake_time?: string | null
+  caffeine_sensitivity?: CaffeineSensitivity
+  timezone?: string
+  chronotype?: Chronotype | null
+  zip_code?: string | null
+  age?: number | null
+  display_mode?: DisplayMode
+  circadian_mode_start?: string
+  onboarding_completed?: boolean
+}


### PR DESCRIPTION
## Summary

- **Onboarding wizard**: 6-step flow (Welcome, Oura, Sleep Profile, Tracking Setup, Data Storage, Done) with per-step settings persistence via PATCH
- **Daily log form**: 11 collapsible entry sections (Caffeine, Meals, Supplements, Habits, Stimulating Activities, Sexual Activity, Pre-Bed Rituals, Naps, Sunlight, Red Light, NSDR) with whole-log PUT save
- **Client-side routing**: react-router-dom v7 with `/log/:date` URL pattern, onboarding guard in Layout
- **Caffeine decay chart**: Pure exponential decay math rendered as inline SVG with bedtime marker and 100mg threshold
- **Foundation**: TypeScript types mirroring backend schemas, thin fetch wrapper with ApiError, shared form primitives (TimePicker, NumberInput, SelectInput, SliderInput, Toggle)
- **77 tests** across 14 files, ESLint clean, TypeScript strict, Vite build passes
- **Docs**: ADR 008 (routing + form pattern), ARCHITECTURE.md updated with frontend component diagram

## New dependency

`react-router-dom` v7 — npm audit clean (only pre-existing eslint `ajv` moderate in devDeps)

## Test plan

- [ ] `cd frontend && npm test` — 77 tests pass
- [ ] `cd frontend && npm run lint` — ESLint clean
- [ ] `cd frontend && npm run build` — TypeScript + Vite build succeeds
- [ ] `make dev` — smoke test: onboarding flow → daily log → add entries → save → copy day → date nav
- [ ] Verify circadian theme: no blue/green/white visible in default mode
- [ ] Security review: no raw SQL, no sensitive data logged, CORS localhost only

🤖 Generated with [Claude Code](https://claude.com/claude-code)