### PR TITLE
Increase default Oura sync range from 30 days to 1 year

### DIFF
--- a/backend/routers/oura.py
+++ b/backend/routers/oura.py
@@ -56,7 +56,7 @@ def sync_oura(
         if settings.last_oura_sync:
             start_date = settings.last_oura_sync.date()
         else:
-            start_date = today - dt.timedelta(days=30)
+            start_date = today - dt.timedelta(days=365)
 
     client = OuraClient(
         token=settings.oura_token,


### PR DESCRIPTION
## Summary
- First-time Oura sync now pulls 365 days of history instead of 30
- Users immediately have enough data for correlation (14+ days) and full regression analysis (50+ days)
- Subsequent syncs still use `last_oura_sync` as the start date

## Test plan
- [x] Backend tests pass (`pytest backend/tests/test_oura_sync.py` — 28 passed)
- [ ] Manual: fresh onboarding with Oura token → verify sync pulls ~1 year of data
- [ ] Manual: Settings → Sync Now after initial sync → verify it only pulls since last sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)