### PR TITLE
Chunk Oura API requests into 30-day windows with pagination

### DIFF
--- a/backend/services/oura_client.py
+++ b/backend/services/oura_client.py
@@ -26,6 +26,9 @@ class OuraClient:
         self._token = token
         self._base_url = base_url.rstrip("/")
 
+    # Oura API rejects date ranges wider than ~30 days.
+    _CHUNK_DAYS = 30
+
     def _get(self, path: str, params: dict[str, str]) -> dict:
         """Make an authenticated GET request to the Oura API."""
         try:
@@ -50,6 +53,47 @@ class OuraClient:
 
         return resp.json()
 
+    def _get_paginated(self, path: str, params: dict[str, str]) -> list[dict]:
+        """Fetch all pages of a paginated Oura API endpoint."""
+        all_data: list[dict] = []
+        current_params = dict(params)
+        while True:
+            data = self._get(path, current_params)
+            all_data.extend(data.get("data", []))
+            next_token = data.get("next_token")
+            if not next_token:
+                break
+            current_params["next_token"] = next_token
+        return all_data
+
+    @staticmethod
+    def _date_chunks(
+        start_date: dt.date, end_date: dt.date, chunk_days: int
+    ) -> list[tuple[dt.date, dt.date]]:
+        """Split a date range into chunks of at most chunk_days."""
+        chunks: list[tuple[dt.date, dt.date]] = []
+        current = start_date
+        while current <= end_date:
+            chunk_end = min(current + dt.timedelta(days=chunk_days - 1), end_date)
+            chunks.append((current, chunk_end))
+            current = chunk_end + dt.timedelta(days=1)
+        return chunks
+
+    def _get_chunked(
+        self, path: str, start_date: dt.date, end_date: dt.date
+    ) -> list[dict]:
+        """Fetch data across a large date range by chunking into smaller requests."""
+        all_data: list[dict] = []
+        for chunk_start, chunk_end in self._date_chunks(
+            start_date, end_date, self._CHUNK_DAYS
+        ):
+            results = self._get_paginated(
+                path,
+                {"start_date": str(chunk_start), "end_date": str(chunk_end)},
+            )
+            all_data.extend(results)
+        return all_data
+
     def get_daily_sleep(
         self, start_date: dt.date, end_date: dt.date
     ) -> list[dict]:
@@ -57,31 +101,19 @@ class OuraClient:
 
         Returns list of daily sleep objects keyed by 'day'.
         """
-        data = self._get(
-            "/usercollection/daily_sleep",
-            {"start_date": str(start_date), "end_date": str(end_date)},
-        )
-        return data.get("data", [])
+        return self._get_chunked("/usercollection/daily_sleep", start_date, end_date)
 
     def get_daily_readiness(
         self, start_date: dt.date, end_date: dt.date
     ) -> list[dict]:
         """Fetch daily readiness scores from Oura API v2."""
-        data = self._get(
-            "/usercollection/daily_readiness",
-            {"start_date": str(start_date), "end_date": str(end_date)},
-        )
-        return data.get("data", [])
+        return self._get_chunked("/usercollection/daily_readiness", start_date, end_date)
 
     def get_sleep_periods(
         self, start_date: dt.date, end_date: dt.date
     ) -> list[dict]:
         """Fetch detailed sleep periods (HRV, HR, stages, etc.) from Oura API v2."""
-        data = self._get(
-            "/usercollection/sleep",
-            {"start_date": str(start_date), "end_date": str(end_date)},
-        )
-        return data.get("data", [])
+        return self._get_chunked("/usercollection/sleep", start_date, end_date)
 
 
 def _seconds_to_minutes(seconds: int | None) -> int | None:

--- a/backend/tests/test_oura_sync.py
+++ b/backend/tests/test_oura_sync.py
@@ -223,6 +223,75 @@ class TestOuraClient:
         url = mock_get.call_args.args[0]
         assert url == "https://api.ouraring.com/v2/usercollection/sleep"
 
+    def test_date_chunks_splits_large_range(self) -> None:
+        chunks = OuraClient._date_chunks(
+            dt.date(2026, 1, 1), dt.date(2026, 3, 31), 30
+        )
+        # 90 days → 3 chunks of 30
+        assert len(chunks) == 3
+        assert chunks[0] == (dt.date(2026, 1, 1), dt.date(2026, 1, 30))
+        assert chunks[1] == (dt.date(2026, 1, 31), dt.date(2026, 3, 1))
+        assert chunks[2] == (dt.date(2026, 3, 2), dt.date(2026, 3, 31))
+
+    def test_date_chunks_single_chunk_for_small_range(self) -> None:
+        chunks = OuraClient._date_chunks(
+            dt.date(2026, 2, 1), dt.date(2026, 2, 10), 30
+        )
+        assert len(chunks) == 1
+        assert chunks[0] == (dt.date(2026, 2, 1), dt.date(2026, 2, 10))
+
+    def test_date_chunks_single_day(self) -> None:
+        chunks = OuraClient._date_chunks(
+            dt.date(2026, 2, 15), dt.date(2026, 2, 15), 30
+        )
+        assert len(chunks) == 1
+        assert chunks[0] == (dt.date(2026, 2, 15), dt.date(2026, 2, 15))
+
+    def test_large_range_makes_multiple_api_calls(self) -> None:
+        """A 60-day range should produce 2 HTTP request chunks."""
+        client = OuraClient(token="test-token", base_url="https://api.ouraring.com/v2")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"day": "2026-01-15", "score": 80}]}
+
+        mock_get = MagicMock(return_value=mock_resp)
+        with patch("httpx.Client") as mock_http:
+            mock_http.return_value.__enter__ = MagicMock(return_value=MagicMock(get=mock_get))
+            mock_http.return_value.__exit__ = MagicMock(return_value=False)
+            result = client.get_daily_sleep(dt.date(2026, 1, 1), dt.date(2026, 3, 1))
+
+        # 60 days → 2 chunks → 2 HTTP calls, each returning 1 item
+        assert mock_get.call_count == 2
+        assert len(result) == 2
+
+    def test_pagination_follows_next_token(self) -> None:
+        """When the API returns a next_token, the client should follow it."""
+        client = OuraClient(token="test-token", base_url="https://api.ouraring.com/v2")
+
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            "data": [{"day": "2026-02-15", "score": 82}],
+            "next_token": "abc123",
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "data": [{"day": "2026-02-16", "score": 75}],
+        }
+
+        mock_get = MagicMock(side_effect=[page1, page2])
+        with patch("httpx.Client") as mock_http:
+            mock_http.return_value.__enter__ = MagicMock(return_value=MagicMock(get=mock_get))
+            mock_http.return_value.__exit__ = MagicMock(return_value=False)
+            result = client.get_daily_sleep(dt.date(2026, 2, 15), dt.date(2026, 2, 16))
+
+        assert len(result) == 2
+        assert mock_get.call_count == 2
+        # Second call should include next_token
+        second_call_params = mock_get.call_args_list[1].kwargs["params"]
+        assert second_call_params["next_token"] == "abc123"
+
     def test_generic_400_error(self) -> None:
         client = OuraClient(token="test-token", base_url="https://api.ouraring.com/v2")
         mock_resp = MagicMock()


### PR DESCRIPTION
## Summary
- Oura API rejects date ranges wider than ~30 days with HTTP 400
- `OuraClient` now splits large ranges into 30-day chunks via `_date_chunks()`
- Each chunk follows `next_token` pagination via `_get_paginated()`
- Enables the 1-year default sync from PR #15 to actually work

## Test plan
- [x] All 33 Oura tests pass (28 existing + 5 new)
- [x] Full test suite passes (`make test` — 150 frontend, 393 backend)
- [ ] Manual: Settings → Sync Now pulls full year of Oura data without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)