### PR TITLE
Fix timezone bugs: sleep midpoint and sync time display

### DIFF
--- a/backend/routers/settings.py
+++ b/backend/routers/settings.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import datetime as dt
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 
@@ -34,7 +36,11 @@ def _settings_to_out(settings: UserSettings) -> UserSettingsOut:
         display_mode=settings.display_mode,
         circadian_mode_start=settings.circadian_mode_start,
         onboarding_completed=settings.onboarding_completed,
-        last_oura_sync=settings.last_oura_sync,
+        last_oura_sync=(
+            settings.last_oura_sync.replace(tzinfo=dt.UTC)
+            if settings.last_oura_sync
+            else None
+        ),
     )
 
 

--- a/backend/services/oura_client.py
+++ b/backend/services/oura_client.py
@@ -92,12 +92,19 @@ def _seconds_to_minutes(seconds: int | None) -> int | None:
 
 
 def _parse_datetime(value: str | None) -> dt.datetime | None:
-    """Parse an ISO 8601 datetime string, or return None."""
+    """Parse an ISO 8601 datetime string, returning a naive local-time datetime.
+
+    Oura returns datetimes with timezone offsets (e.g. "2024-01-15T22:30:00-05:00").
+    We strip the tzinfo to store as naive local time, since the hour/minute values
+    already represent the user's local time and that's what we need for bedtime
+    calculations and display.
+    """
     if value is None:
         return None
     # Oura returns formats like "2024-01-15T22:30:00-05:00"
     # fromisoformat handles this in Python 3.11+
-    return dt.datetime.fromisoformat(value)
+    parsed = dt.datetime.fromisoformat(value)
+    return parsed.replace(tzinfo=None)
 
 
 def build_sleep_records(

--- a/backend/services/stats_engine.py
+++ b/backend/services/stats_engine.py
@@ -302,7 +302,9 @@ def prepare_analysis_dataframe(db: Session) -> pd.DataFrame:
         if r.bedtime is not None and r.wake_time is not None:
             bed_h = _normalize_bedtime_hour(r.bedtime)
             wake_h = r.wake_time.hour + r.wake_time.minute / 60
-            if wake_h < 6:
+            # Ensure wake is always "after" bedtime in the 24+ hour space.
+            # E.g. bedtime 22.5, wake 6.5 → 6.5 < 22.5 → wake becomes 30.5
+            if wake_h < bed_h:
                 wake_h += 24
             row["sleep_midpoint_hour"] = (bed_h + wake_h) / 2
         else:

--- a/backend/tests/test_oura_sync.py
+++ b/backend/tests/test_oura_sync.py
@@ -14,6 +14,7 @@ from backend.models import SleepRecord, UserSettings
 from backend.services.oura_client import (
     OuraAPIError,
     OuraClient,
+    _parse_datetime,
     build_sleep_records,
 )
 
@@ -333,6 +334,56 @@ class TestBuildSleepRecords:
         assert r["total_sleep_minutes"] is None
         assert r["sleep_efficiency"] is None
         assert r["bedtime"] is None
+
+
+# --- _parse_datetime tests ---
+
+
+class TestParseDatetime:
+    """Tests for timezone handling in _parse_datetime."""
+
+    def test_returns_naive_datetime(self) -> None:
+        """Timezone-aware Oura timestamps should be stored as naive local time."""
+        result = _parse_datetime("2026-02-14T22:30:00-05:00")
+        assert result is not None
+        assert result.tzinfo is None
+
+    def test_preserves_local_time_values(self) -> None:
+        """The hour/minute should match the original local time, not UTC."""
+        result = _parse_datetime("2026-02-14T22:30:00-05:00")
+        assert result is not None
+        assert result.hour == 22
+        assert result.minute == 30
+
+    def test_none_returns_none(self) -> None:
+        assert _parse_datetime(None) is None
+
+    def test_naive_input_stays_naive(self) -> None:
+        """Input without timezone offset should work fine."""
+        result = _parse_datetime("2026-02-14T22:30:00")
+        assert result is not None
+        assert result.tzinfo is None
+        assert result.hour == 22
+
+
+class TestBuildSleepRecordsBedtime:
+    """Tests that bedtime/wake_time are stored as naive local datetimes."""
+
+    def test_bedtime_is_naive(self) -> None:
+        records = build_sleep_records([], [], SAMPLE_SLEEP_PERIODS["data"])
+        r = records["2026-02-15"]
+        assert r["bedtime"] is not None
+        assert r["bedtime"].tzinfo is None
+        assert r["bedtime"].hour == 22
+        assert r["bedtime"].minute == 30
+
+    def test_wake_time_is_naive(self) -> None:
+        records = build_sleep_records([], [], SAMPLE_SLEEP_PERIODS["data"])
+        r = records["2026-02-15"]
+        assert r["wake_time"] is not None
+        assert r["wake_time"].tzinfo is None
+        assert r["wake_time"].hour == 6
+        assert r["wake_time"].minute == 15
 
 
 # --- Sync endpoint integration tests ---

--- a/backend/tests/test_settings_router.py
+++ b/backend/tests/test_settings_router.py
@@ -1,6 +1,11 @@
 """Tests for settings and red light panel HTTP endpoints."""
 
+import datetime as dt
+
 from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models import UserSettings
 
 # --- User Settings ---
 
@@ -50,6 +55,23 @@ def test_patch_settings_onboarding(client: TestClient) -> None:
     resp = client.patch("/api/settings", json={"onboarding_completed": True})
     assert resp.status_code == 200
     assert resp.json()["onboarding_completed"] is True
+
+
+def test_last_oura_sync_includes_utc_marker(client: TestClient, db: Session) -> None:
+    """last_oura_sync stored as naive UTC should be serialized with +00:00 offset."""
+    settings = db.get(UserSettings, 1)
+    if settings is None:
+        settings = UserSettings(id=1)
+        db.add(settings)
+    # Store as naive UTC (as the sync endpoint does after SQLAlchemy strips tzinfo)
+    settings.last_oura_sync = dt.datetime(2026, 2, 23, 15, 30, 0)
+    db.commit()
+
+    resp = client.get("/api/settings")
+    data = resp.json()
+    # Should include UTC offset so browsers interpret correctly
+    assert data["last_oura_sync"] is not None
+    assert "+00:00" in data["last_oura_sync"] or "Z" in data["last_oura_sync"]
 
 
 # --- Red Light Panels ---

--- a/backend/tests/test_stats_engine.py
+++ b/backend/tests/test_stats_engine.py
@@ -151,6 +151,7 @@ class TestPrepareAnalysisDataframe:
         assert df.iloc[0]["bedtime_hour"] == pytest.approx(24.5)
 
     def test_sleep_midpoint_computed(self, db: Session):
+        """Bedtime 10 PM, wake 6 AM → midpoint should be ~2 AM (26.0 in 24+ space)."""
         d = dt.date(2025, 1, 1)
         _make_sleep_record(
             db, d,
@@ -160,15 +161,55 @@ class TestPrepareAnalysisDataframe:
         db.commit()
 
         df = prepare_analysis_dataframe(db)
-        # Midpoint of 22.0 and 30.0 (6+24) = 26.0 ... wait, wake_time < 6 so +24
-        # bedtime_hour = 22.0, wake_hour = 6+24=30.0, midpoint = 26.0
-        # Actually wake_time is 6:00 AM, which is not < 6, so wake_hour = 6.0
-        # bedtime_hour = 22.0, wake_hour = 6.0, but 6 is not < 6, so no +24
-        # midpoint = (22 + 6) / 2 = 14.0 — that's wrong
-        # The code checks if wake_h < 6, and 6 is not < 6, so wake_h = 6.0
-        # midpoint = (22 + 6) / 2 = 14.0
-        # This is expected behavior for the code as written
-        assert df.iloc[0]["sleep_midpoint_hour"] == pytest.approx(14.0)
+        # bed_h = 22.0, wake_h = 6.0, since 6.0 < 22.0 → wake_h = 30.0
+        # midpoint = (22.0 + 30.0) / 2 = 26.0 (= 2:00 AM)
+        assert df.iloc[0]["sleep_midpoint_hour"] == pytest.approx(26.0)
+
+    def test_sleep_midpoint_wake_before_6am(self, db: Session):
+        """Bedtime 11 PM, wake 5 AM → midpoint ~2 AM (26.0)."""
+        d = dt.date(2025, 1, 1)
+        _make_sleep_record(
+            db, d,
+            bedtime=dt.datetime(2024, 12, 31, 23, 0),
+            wake_time=dt.datetime(2025, 1, 1, 5, 0),
+        )
+        db.commit()
+
+        df = prepare_analysis_dataframe(db)
+        # bed_h = 23.0, wake_h = 5.0, since 5.0 < 23.0 → wake_h = 29.0
+        # midpoint = (23.0 + 29.0) / 2 = 26.0
+        assert df.iloc[0]["sleep_midpoint_hour"] == pytest.approx(26.0)
+
+    def test_sleep_midpoint_late_bedtime_late_wake(self, db: Session):
+        """Bedtime 1 AM, wake 9 AM → midpoint 5 AM (29.0)."""
+        d = dt.date(2025, 1, 1)
+        _make_sleep_record(
+            db, d,
+            bedtime=dt.datetime(2025, 1, 1, 1, 0),
+            wake_time=dt.datetime(2025, 1, 1, 9, 0),
+        )
+        db.commit()
+
+        df = prepare_analysis_dataframe(db)
+        # bed_h = 1.0 → normalized to 25.0 (< 6 shift)
+        # wake_h = 9.0, since 9.0 < 25.0 → wake_h = 33.0
+        # midpoint = (25.0 + 33.0) / 2 = 29.0 (= 5:00 AM)
+        assert df.iloc[0]["sleep_midpoint_hour"] == pytest.approx(29.0)
+
+    def test_sleep_midpoint_typical_scenario(self, db: Session):
+        """Bedtime 10:30 PM, wake 6:30 AM → midpoint 2:30 AM (26.5)."""
+        d = dt.date(2025, 1, 1)
+        _make_sleep_record(
+            db, d,
+            bedtime=dt.datetime(2024, 12, 31, 22, 30),
+            wake_time=dt.datetime(2025, 1, 1, 6, 30),
+        )
+        db.commit()
+
+        df = prepare_analysis_dataframe(db)
+        # bed_h = 22.5, wake_h = 6.5, since 6.5 < 22.5 → wake_h = 30.5
+        # midpoint = (22.5 + 30.5) / 2 = 26.5 (= 2:30 AM)
+        assert df.iloc[0]["sleep_midpoint_hour"] == pytest.approx(26.5)
 
     def test_is_weekend_flag(self, db: Session):
         # 2025-01-04 is a Saturday


### PR DESCRIPTION
## Summary
- **Sleep midpoint calculation** used `if wake_h < 6` for midnight crossover, which failed when wake was >= 6 AM (e.g., bed 22:30 + wake 6:30 → midpoint was 2:30 PM instead of 2:30 AM). Fixed to `if wake_h < bed_h`.
- **last_oura_sync display** was off by the user's timezone offset — stored as naive UTC but serialized without `Z`/`+00:00`, so `new Date()` in the browser interpreted it as local time. Fixed by re-attaching UTC tzinfo before Pydantic serialization.
- **Oura datetime storage** — strips timezone info from tz-aware Oura timestamps before storage to avoid SQLAlchemy/SQLite ambiguity. Preserves local time values which is what we need for bedtime calculations.

Closes #16, closes #18

## Test plan
- [x] Backend tests pass (403 tests, 94.87% coverage)
- [x] Frontend tests pass (150 tests)
- [x] New midpoint tests cover: typical sleep (bed 10PM/wake 6AM), wake before 6AM, late bedtime after midnight, bed 10:30PM/wake 6:30AM
- [x] New `_parse_datetime` tests verify timezone stripping and local time preservation
- [x] New `last_oura_sync` test verifies UTC marker in serialized output
- [x] Pre-existing TS error in OuraStep.test.tsx confirmed on base branch (not introduced here)
- [ ] Manual: verify sleep midpoint shows ~2 AM (not afternoon) on dashboard
- [ ] Manual: verify "Last sync" time shows correct local time in Settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)